### PR TITLE
docker: run knex migrations before starting the server

### DIFF
--- a/infra/docker/Dockerfile
+++ b/infra/docker/Dockerfile
@@ -87,8 +87,19 @@ p.exports={'.':{'types':'./dist/index.d.ts','default':'./dist/index.js'}};\
 fs.writeFileSync(path,JSON.stringify(p,null,2));"
 RUN mkdir -p /var/lib/vibe/connect/uploads /var/lib/vibe/connect/tls \
  && chown -R vibe:vibe /var/lib/vibe/connect
+
+# Entrypoint runs pending migrations before starting the server. Without
+# this, a fresh install hits /install/status against an unmigrated DB and
+# the SPA shows "Can't reach the server" — the install wizard is then
+# unreachable. Strip CRs in case the build context was checked out on
+# Windows with core.autocrlf=true (otherwise the kernel's execve(2) tries
+# to find an interpreter named `/bin/sh\r` and fails with the misleading
+# "no such file or directory").
+COPY infra/docker/docker-entrypoint.sh /docker-entrypoint.sh
+RUN sed -i 's/\r$//' /docker-entrypoint.sh && chmod +x /docker-entrypoint.sh
+
 USER vibe
 EXPOSE 4000
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD wget -qO- http://127.0.0.1:4000/health || exit 1
-CMD ["node", "apps/server/dist/index.js"]
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/infra/docker/docker-entrypoint.sh
+++ b/infra/docker/docker-entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# Vibe Connect — Docker entrypoint.
+#
+# Runs pending knex migrations against the configured Postgres before
+# starting the server. Without this, a fresh install lands at a server
+# whose first GET /install/status query against `firm_keys` returns 500
+# because the schema hasn't been created — the SPA's InstallGate then
+# shows the "Can't reach the server" screen and the operator never sees
+# the install wizard.
+#
+# Idempotent: knex tracks applied migrations in the `knex_migrations`
+# table, so a re-deploy or container restart is a fast no-op once the
+# schema is current. A failing migration exits non-zero before the
+# server starts so a partially-migrated state never serves traffic;
+# `restart: unless-stopped` will retry and the operator sees the failure
+# in `docker logs`.
+#
+# Lifted from the trial-balance-app's `server/docker-entrypoint.sh`
+# pattern; the two scripts stay close in shape so a fix to one is easy
+# to backport to the other.
+
+set -e
+
+cd /app/apps/server
+
+echo "[entrypoint] running pending migrations..."
+# `npx --no-install knex` finds the knex CLI in the repo's hoisted
+# node_modules without re-resolving from the registry — the runtime
+# image has yarn install --production already, so knex (a production
+# dep) is on disk. --no-install fails fast if it isn't, instead of
+# trying to fetch from npmjs.org with no network.
+npx --no-install knex --knexfile ./knexfile.cjs migrate:latest
+
+echo "[entrypoint] starting Vibe Connect server..."
+exec node dist/index.js


### PR DESCRIPTION
## Summary

Fresh installs of Vibe-Connect would hang on the InstallGate's "Cannot reach the server" message because the server started before its DB schema existed. Adds `infra/docker/docker-entrypoint.sh` that runs \`npx --no-install knex migrate:latest\` before \`node dist/index.js\`, and updates the Dockerfile to use it as the CMD.

## Test plan

- [ ] Fresh install with empty Postgres: container comes up clean, server reaches ready state without manual migrate.
- [ ] Existing install (DB schema already current): \`migrate:latest\` is a no-op and boot time is unchanged.
- [ ] Migration failure: container exits non-zero with the migrate error in the log (no half-started server).