### PR TITLE
chore: upgrade Node 20 → 24 and refresh deprecated Action runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,12 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'yarn'
 
       - name: Install deps

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,13 +28,13 @@ jobs:
       version: ${{ steps.meta.outputs.version }}
       is_release: ${{ steps.meta.outputs.is_release }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -69,7 +69,7 @@ jobs:
       # ---------- Server image (Express API) ----------
       - name: Build + push vibe-connect-server
         id: build_server
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: infra/docker/Dockerfile
@@ -88,7 +88,7 @@ jobs:
       # ---------- Client image (nginx serving SPA) ----------
       - name: Build + push vibe-connect-client
         id: build_client
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: infra/docker/nginx/Dockerfile
@@ -143,11 +143,11 @@ jobs:
       updater_path: ${{ steps.locate.outputs.updater_path }}
       updater_sig_path: ${{ steps.locate.outputs.updater_sig_path }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'yarn'
 
       - uses: dtolnay/rust-toolchain@stable
@@ -155,7 +155,7 @@ jobs:
           targets: x86_64-pc-windows-msvc
 
       - name: Cache cargo registry + target
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           # Keying on Cargo.lock so a dep bump invalidates cleanly. The
           # target dir is not cached because Tauri's wry build emits absolute
@@ -221,7 +221,7 @@ jobs:
 
       - name: Upload MSI artifact
         if: steps.locate.outputs.msi_path != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: vibe-connect-desktop-msi-${{ needs.build-and-push.outputs.version }}
           path: ${{ steps.locate.outputs.msi_path }}
@@ -229,7 +229,7 @@ jobs:
 
       - name: Upload NSIS artifact
         if: steps.locate.outputs.nsis_path != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: vibe-connect-desktop-nsis-${{ needs.build-and-push.outputs.version }}
           path: ${{ steps.locate.outputs.nsis_path }}
@@ -237,7 +237,7 @@ jobs:
 
       - name: Upload updater bundle (signed)
         if: steps.locate.outputs.updater_path != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: vibe-connect-desktop-updater-${{ needs.build-and-push.outputs.version }}
           path: |
@@ -247,7 +247,7 @@ jobs:
 
       - name: Attach to GitHub release
         if: needs.build-and-push.outputs.is_release == 'true'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             ${{ steps.locate.outputs.msi_path }}
@@ -273,7 +273,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: gh-pages
           # Allow the workflow to push back to gh-pages.
@@ -296,7 +296,7 @@ jobs:
           fi
 
       - name: Download updater bundle
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: vibe-connect-desktop-updater-${{ needs.build-and-push.outputs.version }}
           path: ./_updater

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ of the Vibe product family (Vibe TB, Vibe MyBooks). See `vibe-connect-build-plan
 
 ## Stack pins
 
-- Node 20, TypeScript strict (all strict flags in `tsconfig.base.json`).
+- Node 24, TypeScript strict (all strict flags in `tsconfig.base.json`).
 - yarn workspaces (see `package.json workspaces`).
 - Postgres 16.
 - React 18 + Vite + Tailwind CSS for staff + portal.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Part of the Vibe product family alongside Vibe TB and Vibe MyBooks.
 
 ## What's here
 
-- `apps/server` — Node 20 + Express + Knex + Postgres 16 + Socket.io
+- `apps/server` — Node 24 + Express + Knex + Postgres 16 + Socket.io
 - `apps/web` — Staff app (Vite + React 18 + TypeScript + Tailwind)
 - `apps/portal` — Client portal (Vite + React 18 + TypeScript + Tailwind)
 - `apps/desktop` — Tauri 2.x wrapper around the staff web bundle
@@ -18,7 +18,7 @@ Part of the Vibe product family alongside Vibe TB and Vibe MyBooks.
 
 See `vibe-connect-build-plan.md` for the full plan. Quick summary:
 
-- Node 20, TypeScript strict, yarn workspaces
+- Node 24, TypeScript strict, yarn workspaces
 - PostgreSQL 16 via Docker compose
 - libsodium (`libsodium-wrappers`) for all crypto (XChaCha20-Poly1305 + X25519 + Argon2id)
 - Socket.io + Postgres `LISTEN/NOTIFY` for real-time

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "./src/index.ts",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=24.0.0"
   },
   "packageManager": "yarn@1.22.22",
   "scripts": {

--- a/docs/vibe-connect-compatibility-addendum.md
+++ b/docs/vibe-connect-compatibility-addendum.md
@@ -43,7 +43,7 @@ Plus one Connect-specific rule:
 | Item | Today | Target | Notes |
 |---|---|---|---|
 | **License** | **Proprietary** | **ELv2** | **§0 BLOCKER** |
-| Stack | React 18 + TS + Node 20 + Express + Socket.io + PG16 + Redis + libsodium + Tauri 2 desktop | Same | No stack changes |
+| Stack | React 18 + TS + Node 24 + Express + Socket.io + PG16 + Redis + libsodium + Tauri 2 desktop | Same | No stack changes |
 | Standalone install | Existing flow | Unchanged | Audit |
 | GHCR images | Need verification | Multi-arch (amd64 + arm64), three image families: server, web, portal | §5.10 |
 | DB / Redis config | Mixed assumed | `DATABASE_URL` / `REDIS_URL` only | §3 (common) |

--- a/infra/docker/Dockerfile
+++ b/infra/docker/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7
 # Multi-stage appliance image: server + web + portal in one container, Alpine-based.
 
-FROM node:20-alpine AS deps
+FROM node:24-alpine AS deps
 WORKDIR /app
 RUN apk add --no-cache python3 make g++ libc6-compat
 COPY package.json yarn.lock ./
@@ -17,7 +17,7 @@ COPY packages/crypto/package.json packages/crypto/
 # native bindings compile once.
 RUN yarn install --frozen-lockfile
 
-FROM node:20-alpine AS build
+FROM node:24-alpine AS build
 WORKDIR /app
 COPY --from=deps /app /app
 COPY . .
@@ -27,7 +27,7 @@ RUN yarn workspace @vibe-connect/server build
 RUN yarn workspace @vibe-connect/web build
 RUN yarn workspace @vibe-connect/portal build
 
-FROM node:20-alpine AS runtime
+FROM node:24-alpine AS runtime
 WORKDIR /app
 # Pin the in-container user to a fixed uid/gid (10001:10001) so host
 # bind-mounts under /var/lib/vibe/connect/{uploads,tls,...} have a stable

--- a/infra/docker/nginx/Dockerfile
+++ b/infra/docker/nginx/Dockerfile
@@ -9,7 +9,7 @@
 # keeps node_modules / .git / .env out of the upload step.
 
 # --- deps -----------------------------------------------------------------
-FROM node:20-alpine AS deps
+FROM node:24-alpine AS deps
 WORKDIR /app
 RUN apk add --no-cache python3 make g++ libc6-compat
 COPY package.json yarn.lock ./
@@ -22,7 +22,7 @@ COPY packages/crypto/package.json packages/crypto/
 RUN yarn install --frozen-lockfile
 
 # --- build frontend -------------------------------------------------------
-FROM node:20-alpine AS build
+FROM node:24-alpine AS build
 WORKDIR /app
 COPY --from=deps /app /app
 COPY . .

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "packages/*"
   ],
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=24.0.0"
   },
   "packageManager": "yarn@1.22.22",
   "scripts": {
@@ -35,7 +35,7 @@
     "@types/express-serve-static-core": "^4.19.5"
   },
   "devDependencies": {
-    "@types/node": "^20.14.10",
+    "@types/node": "^24.0.0",
     "@typescript-eslint/eslint-plugin": "^7.16.0",
     "@typescript-eslint/parser": "^7.16.0",
     "eslint": "^8.57.0",

--- a/vibe-connect-build-plan.md
+++ b/vibe-connect-build-plan.md
@@ -23,7 +23,7 @@ Replace PinkNotes inside Kurt's own firm as an internal-staff communication tool
 ## Stack
 
 - **Frontend:** React 18 + TypeScript + Vite + Tailwind CSS
-- **Backend:** Node.js 20 + Express + Knex.js (plain-JS migrations)
+- **Backend:** Node.js 24 + Express + Knex.js (plain-JS migrations)
 - **Database:** PostgreSQL 16
 - **Real-time:** Socket.io + Postgres `LISTEN/NOTIFY`
 - **File storage:** Local filesystem in appliance volume (S3 driver optional)

--- a/vibe-connect-droplet-addendum.md
+++ b/vibe-connect-droplet-addendum.md
@@ -632,7 +632,7 @@ See the **File storage architecture** section above for guidance on choosing bet
 
 Generate VAPID keys:
 ```bash
-docker run --rm node:20-alpine npx web-push generate-vapid-keys
+docker run --rm node:24-alpine npx web-push generate-vapid-keys
 ```
 
 Paste the output into `.env`.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2164,12 +2164,12 @@
   dependencies:
     undici-types "~7.19.0"
 
-"@types/node@^20.14.10":
-  version "20.19.39"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.19.39.tgz#e98a3b575574070cd34b784bd173767269f95e99"
-  integrity sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==
+"@types/node@^24.0.0":
+  version "24.12.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.12.2.tgz#353cb161dbf1785ea25e8829ba7ec574c5c629ac"
+  integrity sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==
   dependencies:
-    undici-types "~6.21.0"
+    undici-types "~7.16.0"
 
 "@types/nodemailer@^6.4.15":
   version "6.4.23"
@@ -6611,10 +6611,10 @@ unbox-primitive@^1.1.0:
     has-symbols "^1.1.0"
     which-boxed-primitive "^1.1.1"
 
-undici-types@~6.21.0:
-  version "6.21.0"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
-  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
+undici-types@~7.16.0:
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.16.0.tgz#ffccdff36aea4884cbfce9a750a0580224f58a46"
+  integrity sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==
 
 undici-types@~7.19.0:
   version "7.19.2"


### PR DESCRIPTION
## Summary

Node 20 LTS hit EOL on 2026-04-30 and GitHub is sunsetting the `node20` Actions runtime. This PR moves the project to Node 24 LTS and refreshes every deprecated GitHub Action.

### Project pins
- `engines.node` (root + `apps/server`) → `>=24.0.0`
- `@types/node` `^20.14.10` → `^24.0.0`
- `infra/docker/Dockerfile` + `nginx/Dockerfile` → `node:24-alpine`
- `ci.yml` + `release.yml` `node-version` → `'24'`
- Docs: CLAUDE.md, README, build plan, compatibility addendum, droplet addendum, VAPID example

### Action pins (all verified `runs.using: node24` on the new majors)
| Action | Was | Now |
|---|---|---|
| `actions/checkout` | v4 | v5 |
| `actions/setup-node` | v4 | v5 |
| `actions/cache` | v4 | v5 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `docker/setup-qemu-action` | v3 | v4 |
| `docker/setup-buildx-action` | v3 | v4 |
| `docker/login-action` | v3 | v4 |
| `docker/build-push-action` | v5 | v7 |
| `softprops/action-gh-release` | v2 | v3 |

Left as-is: `sigstore/cosign-installer@v3` (composite, not deprecated) and `dtolnay/rust-toolchain@stable`.

Reviewed each major bump against release notes — no breaking changes apply to our usage (no `archive: false`, no single-by-ID artifact downloads, no `DOCKER_BUILD_NO_SUMMARY` env).

## Test plan

Local verification inside `node:24-alpine`:
- [x] `yarn install --frozen-lockfile`
- [x] `yarn typecheck` across all 6 workspaces
- [x] `yarn lint` (0 warnings)
- [x] `yarn format:check`
- [x] `yarn test` — **329/329 passing** (server 275, web 21, crypto 33)
- [x] Full server + nginx images build cleanly
- [x] Smoke boot: 41 knex migrations apply, `/health` + `/__vibe-boot.js` + `/install/status` + `/ping` respond, libsodium loads
- [ ] CI green on this branch
- [ ] Tauri desktop build (only runs on tag pushes — first real test is the next `vX.Y.Z` tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)