### PR TITLE
fix(nginx): mount /intake on the portal subdomain

### DIFF
--- a/infra/docker/nginx/nginx.conf.template
+++ b/infra/docker/nginx/nginx.conf.template
@@ -260,6 +260,40 @@ http {
       proxy_set_header X-Forwarded-Proto $vibe_forwarded_proto;
     }
 
+    # Phase 28.3 — anonymous intake API on the portal subdomain.
+    # Mirrors the staff block; clients reach this from tokenized intake
+    # links (apps/server sends portalUrl + /api/public/intake/... in
+    # emails) and from the public "Send us files" landing card. `^~` so
+    # it beats the catch-all `/` below.
+    location ^~ /api/public/intake/ {
+      set $app_backend http://app:4000;
+      proxy_pass $app_backend;
+      proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $vibe_forwarded_proto;
+    }
+
+    # Phase 28.3 — anonymous intake SPA on the portal subdomain.
+    # The intake bundle is the public, no-auth client-upload surface; it
+    # MUST be reachable on the client portal subdomain so the URLs
+    # emitted in client-facing emails are client-branded
+    # (`client.<domain>/intake/t/<token>`), not staff-branded
+    # (`vibe.<domain>/connect/intake/...`). The staff block keeps its own
+    # /intake mount for staff preview / debugging.
+    #
+    # Substitutes PORTAL_BASE_PATH_HREF (not BASE_PATH_HREF) because the
+    # intake bundle's source HTML carries `<base href="__BASE_HREF__/intake/">`
+    # and on the portal subdomain we want `<base href="/intake/">`, not
+    # `<base href="/connect/intake/">` (which would 404 every asset).
+    location ^~ /intake {
+      root /usr/share/nginx/html/intake;
+      rewrite ^/intake/?(.*)$ /$1 break;
+      try_files $uri $uri/ /index.html;
+      sub_filter_types application/manifest+json;
+      sub_filter '__BASE_HREF__' '${PORTAL_BASE_PATH_HREF}';
+      sub_filter_once off;
+    }
+
     location / {
       root /usr/share/nginx/html/portal;
       try_files $uri $uri/ /index.html;
@@ -448,6 +482,28 @@ http {
       proxy_set_header Host $host;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $vibe_forwarded_proto;
+    }
+
+    # Anonymous intake API + SPA on the portal subdomain. See the
+    # TLS-internal portal block above for the rationale. This block is
+    # the surface clients actually reach in appliance deployments (Caddy
+    # / Cloudflare Tunnel terminates TLS upstream and proxies plain HTTP
+    # to PORTAL_HTTP_PORT).
+    location ^~ /api/public/intake/ {
+      set $app_backend http://app:4000;
+      proxy_pass $app_backend;
+      proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $vibe_forwarded_proto;
+    }
+
+    location ^~ /intake {
+      root /usr/share/nginx/html/intake;
+      rewrite ^/intake/?(.*)$ /$1 break;
+      try_files $uri $uri/ /index.html;
+      sub_filter_types application/manifest+json;
+      sub_filter '__BASE_HREF__' '${PORTAL_BASE_PATH_HREF}';
+      sub_filter_once off;
     }
 
     location / {


### PR DESCRIPTION
## Summary

- Add `^~ /intake` and `^~ /api/public/intake/` blocks to both portal server blocks in `nginx.conf.template` (TLS-internal HTTPS on `PORTAL_HTTPS_PORT`, plain HTTP on `PORTAL_HTTP_PORT`). The intake SPA was only routed by the staff blocks — the portal listener had no `/intake` location, so client requests fell through to the catch-all `location /` and served the portal bundle, whose router has no `/intake` route → catch-all `<Navigate to="/" replace />` → sign-in form.
- Sub_filter substitutes `${PORTAL_BASE_PATH_HREF}` (not `BASE_PATH_HREF`) so the intake bundle's `<base href="__BASE_HREF__/intake/">` resolves to `<base href="/intake/">` on the client subdomain instead of `<base href="/connect/intake/">` (which would 404 every Vite-emitted relative asset against the portal listener's `/usr/share/nginx/html/intake` root).
- Staff `/intake` mount kept as-is — handy for staff preview / debug without leaving the staff subdomain.

## Why this matters

The multi-subdomain split (staff at `vibe.<domain>/connect`, clients at `client.<domain>`) was built so client-facing URLs stay client-branded. Tokenized intake links and the public "Send us files" landing card both point at `portalUrl + /intake/...` — that's the client subdomain. The portal nginx listener accepts the request but doesn't actually serve the bundle the URL points at; clients land on the firm-portal login screen instead of the upload form.

Caught while testing Vibe-Appliance v0.4.8 against `cpa2web.app`:
```
$ curl -sI https://client.cpa2web.app/intake | head -3
HTTP/1.1 200 OK
Content-Type: text/html
$ # …serves the PORTAL index.html, not the intake bundle
```

After this change, the same URL serves the intake `index.html` with `<base href="/intake/">` and Vite-emitted `./assets/*.js` resolves to `/intake/assets/*.js` against the matching nginx location.

## Test plan

- [ ] `nginx -t` on a rendered config in `TLS_MODE=external` (the appliance deploy path)
- [ ] `nginx -t` on a rendered config in `TLS_MODE=internal` (single-app deployments)
- [ ] `curl https://client.<domain>/intake` returns the intake bundle's `index.html` (title "Send files", `<base href="/intake/">`)
- [ ] `curl https://client.<domain>/intake/assets/<hash>.js` returns the chunk from `/usr/share/nginx/html/intake/assets/`
- [ ] `curl https://client.<domain>/intake/t/<token>` returns the intake bundle's `index.html` (SPA fallback for deep routes)
- [ ] `curl https://vibe.<domain>/connect/intake` still returns the intake bundle (staff mount unbroken)
- [ ] Portal SPA's own routes (`/`, `/invite`, `/messages`, `/files`, etc.) still resolve to the portal bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)