### PR TITLE
feat(email): add Emailit v2 provider + surface SMTP errors in invite toasts

### DIFF
--- a/apps/server/src/__tests__/emailit-provider.test.ts
+++ b/apps/server/src/__tests__/emailit-provider.test.ts
@@ -1,0 +1,122 @@
+/**
+ * EmailitProvider unit test. Stubs global fetch so we can assert the wire
+ * shape we send to api.emailit.com — this is the layer the production
+ * implementation in another Vibe product got wrong on its first cut
+ * (v1 URL, object-shaped `from`, array-of-object `to`). Locking the
+ * contract here is cheap insurance against the same regression here.
+ */
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resetTestDb } from './test-helpers.js';
+
+beforeAll(async () => {
+  process.env.NODE_ENV = 'test';
+  process.env.DATABASE_URL =
+    process.env.TEST_DATABASE_URL ?? 'postgres://vibe:vibe@localhost:5435/vibe_connect_test';
+  await resetTestDb();
+});
+
+beforeEach(async () => {
+  const { db } = await import('../db/knex.js');
+  await db('firm_provider_credentials').del();
+  await db('firm_settings').where({ id: 1 }).update({ email_provider: 'emailit' });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('EmailitProvider', () => {
+  it('posts to /v2/emails with bearer auth and RFC 5322 fields', async () => {
+    const { set } = await import('../services/providerSecrets.js');
+    await set('email.emailit.api_key', 'test-key-abc', null);
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ id: 'em_123', status: 'queued' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    const { getEmailProvider } = await import('../bridges/email/index.js');
+    const provider = await getEmailProvider();
+    expect(provider.name).toBe('emailit');
+
+    const result = await provider.send({
+      to: 'client@example.com',
+      subject: 'hello',
+      text: 'plain body',
+      html: '<p>html body</p>',
+    });
+
+    expect(result.id).toBe('em_123');
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [urlArg, initArg] = fetchSpy.mock.calls[0]!;
+    expect(String(urlArg)).toBe('https://api.emailit.com/v2/emails');
+    const init = initArg as RequestInit;
+    expect(init.method).toBe('POST');
+    const headers = init.headers as Record<string, string>;
+    expect(headers.authorization).toBe('Bearer test-key-abc');
+    expect(headers['content-type']).toBe('application/json');
+    const sent = JSON.parse(String(init.body)) as Record<string, unknown>;
+    // `from` must be a string (RFC 5322), not {email, name}.
+    expect(typeof sent.from).toBe('string');
+    // `to` must be a string (or string[]), never [{email}].
+    expect(typeof sent.to === 'string' || Array.isArray(sent.to)).toBe(true);
+    expect(sent.subject).toBe('hello');
+    expect(sent.text).toBe('plain body');
+    expect(sent.html).toBe('<p>html body</p>');
+  });
+
+  it('honors the firm-overridden base URL', async () => {
+    const { set } = await import('../services/providerSecrets.js');
+    await set('email.emailit.api_key', 'test-key', null);
+    await set('email.emailit.base_url', 'https://eu.api.emailit.com/v2/', null);
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ id: 'em_eu' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    const { getEmailProvider } = await import('../bridges/email/index.js');
+    const provider = await getEmailProvider();
+    await provider.send({ to: 'a@b.com', subject: 's', text: 't' });
+
+    const [urlArg] = fetchSpy.mock.calls[0]!;
+    // Trailing slash stripped, /emails appended.
+    expect(String(urlArg)).toBe('https://eu.api.emailit.com/v2/emails');
+  });
+
+  it('throws a redacted error on non-2xx', async () => {
+    const { set } = await import('../services/providerSecrets.js');
+    await set('email.emailit.api_key', 'test-key', null);
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('{"error":"bad_auth","trace":"abcdefghijklmnopqrstuvwxyz0123456789"}', {
+        status: 401,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    const { getEmailProvider } = await import('../bridges/email/index.js');
+    const provider = await getEmailProvider();
+    await expect(provider.send({ to: 'a@b.com', subject: 's', text: 't' })).rejects.toThrow(
+      /emailit_401/,
+    );
+  });
+
+  it('throws when api_key is missing', async () => {
+    // No secret stored, env fallback also empty (tests start with EMAILIT_API_KEY unset).
+    const { getEmailProvider } = await import('../bridges/email/index.js');
+    const provider = await getEmailProvider();
+    await expect(provider.send({ to: 'a@b.com', subject: 's', text: 't' })).rejects.toThrow(
+      /emailit_api_key_not_configured/,
+    );
+  });
+});
+
+afterAll(async () => {
+  const { db } = await import('../db/knex.js');
+  await db.destroy();
+});

--- a/apps/server/src/__tests__/provider-selection.test.ts
+++ b/apps/server/src/__tests__/provider-selection.test.ts
@@ -49,6 +49,9 @@ describe('DB-backed provider selection', () => {
 
     await db('firm_settings').where({ id: 1 }).update({ email_provider: 'postfix' });
     expect((await getEmailProvider()).name).toBe('postfix');
+
+    await db('firm_settings').where({ id: 1 }).update({ email_provider: 'emailit' });
+    expect((await getEmailProvider()).name).toBe('emailit');
   });
 
   it('getSmsProvider honors firm_settings.sms_provider', async () => {
@@ -104,6 +107,32 @@ describe('DB-backed provider selection', () => {
         keys: ['email.postmark.server_token'],
       },
     ]);
+  });
+
+  it('pre-flight rejects switching to emailit when api_key is missing', async () => {
+    const { db } = await import('../db/knex.js');
+    await db('firm_provider_credentials').delete();
+    const admin = await loginAs('kurt', 'kurt-dev-only-ChangeMe!');
+    const res = await admin.patch('/admin/settings').send({ emailProvider: 'emailit' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('provider_secrets_missing');
+    expect(res.body.missing).toEqual([
+      {
+        field: 'emailProvider',
+        provider: 'emailit',
+        keys: ['email.emailit.api_key'],
+      },
+    ]);
+  });
+
+  it('PATCH /admin/settings persists emailit once api_key is stored', async () => {
+    const { set: setProviderSecret } = await import('../services/providerSecrets.js');
+    await setProviderSecret('email.emailit.api_key', 'test-emailit-key-xyz', null);
+    const admin = await loginAs('kurt', 'kurt-dev-only-ChangeMe!');
+    const patched = await admin.patch('/admin/settings').send({ emailProvider: 'emailit' });
+    expect(patched.status).toBe(200);
+    const read = await admin.get('/admin/settings');
+    expect(read.body.settings.email_provider).toBe('emailit');
   });
 });
 

--- a/apps/server/src/bridges/email/index.ts
+++ b/apps/server/src/bridges/email/index.ts
@@ -88,6 +88,88 @@ class PostmarkProvider implements EmailProvider {
   }
 }
 
+// Emailit v2 transactional API (https://emailit.com/docs/api-reference/emails/send/).
+// Ported from the production client in Vibe-Payroll-Time —
+// notable details an earlier integration in another product got wrong:
+//   * URL is /v2/ (not /v1/).
+//   * `from` is an RFC 5322 string ("Name <email>" or bare email), not a
+//     {email, name} object.
+//   * `to` is a string or string[], not an [{email}] array.
+//   * Auth is Bearer <api_key>.
+const DEFAULT_EMAILIT_BASE_URL = 'https://api.emailit.com/v2';
+const EMAILIT_TIMEOUT_MS = 15_000;
+class EmailitProvider implements EmailProvider {
+  name = 'emailit';
+  async send(msg: EmailMessage) {
+    const apiKey = await getOrEnvFallback('email.emailit.api_key', env.emailitApiKey);
+    if (!apiKey) throw new Error('emailit_api_key_not_configured');
+    const baseRaw =
+      (await getOrEnvFallback('email.emailit.base_url', env.emailitBaseUrl)) ??
+      DEFAULT_EMAILIT_BASE_URL;
+    const base = baseRaw.replace(/\/+$/, '');
+    const replyTo =
+      msg.replyTo ??
+      (await getOrEnvFallback('email.emailit.reply_to', env.emailitReplyTo)) ??
+      undefined;
+    // The API wants the From in RFC 5322 form. env.emailFrom may already be
+    // "Name <email>" (the default) or a bare address — either way we hand
+    // it through as a string.
+    const body = {
+      from: env.emailFrom,
+      to: msg.to,
+      subject: msg.subject,
+      text: msg.text,
+      html: msg.html,
+      ...(replyTo ? { reply_to: replyTo } : {}),
+      ...(msg.headers && Object.keys(msg.headers).length > 0 ? { headers: msg.headers } : {}),
+    };
+    let res: Response;
+    try {
+      res = await fetch(`${base}/emails`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${apiKey}`,
+          'content-type': 'application/json',
+          accept: 'application/json',
+        },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(EMAILIT_TIMEOUT_MS),
+      });
+    } catch (err) {
+      const isTimeout = err instanceof DOMException && err.name === 'TimeoutError';
+      throw new Error(
+        isTimeout
+          ? `emailit_timeout_after_${EMAILIT_TIMEOUT_MS}ms`
+          : `emailit_network_error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    if (!res.ok) {
+      // Strip anything that looks like a bearer token from the body before
+      // surfacing it — matches the redaction posture of PostmarkProvider.
+      const txt = (await res.text()).replace(/[A-Za-z0-9_-]{24,}/g, '[redacted]');
+      throw new Error(`emailit_${res.status}: ${txt.slice(0, 200)}`);
+    }
+    let parsed: unknown = null;
+    try {
+      parsed = await res.json();
+    } catch {
+      parsed = null;
+    }
+    const pick = (v: unknown, k: string): string | null => {
+      if (!v || typeof v !== 'object') return null;
+      const x = (v as Record<string, unknown>)[k];
+      return typeof x === 'string' ? x : null;
+    };
+    const id =
+      pick(parsed, 'id') ??
+      pick(parsed, 'message_id') ??
+      pick((parsed as { data?: unknown } | null)?.data, 'id') ??
+      `emailit-${Date.now()}`;
+    logger.info('email.emailit_sent', { to: msg.to, id });
+    return { id, status: 'sent' as const };
+  }
+}
+
 class PostfixProvider implements EmailProvider {
   name = 'postfix';
   // Transport is re-resolved per-send so rotating SMTP settings in the admin
@@ -139,13 +221,21 @@ class PostfixProvider implements EmailProvider {
  *  firm_settings.email_provider enum doesn't include 'none' precisely
  *  because we don't want an admin clicking it off — the appliance
  *  operator does. */
-async function resolveEmailProviderKind(): Promise<'mock' | 'postmark' | 'postfix' | 'none'> {
+async function resolveEmailProviderKind(): Promise<
+  'mock' | 'postmark' | 'postfix' | 'emailit' | 'none'
+> {
   if (env.emailProvider === 'none') return 'none';
   try {
     const { db } = await import('../../db/knex.js');
     const row = await db('firm_settings').where({ id: 1 }).first('email_provider');
     const picked = row?.email_provider as string | undefined;
-    if (picked === 'postmark' || picked === 'postfix' || picked === 'mock') return picked;
+    if (
+      picked === 'postmark' ||
+      picked === 'postfix' ||
+      picked === 'emailit' ||
+      picked === 'mock'
+    )
+      return picked;
   } catch (err) {
     // DB unreachable (boot race, maintenance window). Fall through to env so
     // we fail safer — a misconfigured DB shouldn't break outbound mail.
@@ -162,6 +252,8 @@ export async function getEmailProvider(): Promise<EmailProvider> {
       return new PostmarkProvider();
     case 'postfix':
       return new PostfixProvider();
+    case 'emailit':
+      return new EmailitProvider();
     case 'none':
       return new NoneProvider();
     case 'mock':

--- a/apps/server/src/bridges/email/index.ts
+++ b/apps/server/src/bridges/email/index.ts
@@ -229,12 +229,7 @@ async function resolveEmailProviderKind(): Promise<
     const { db } = await import('../../db/knex.js');
     const row = await db('firm_settings').where({ id: 1 }).first('email_provider');
     const picked = row?.email_provider as string | undefined;
-    if (
-      picked === 'postmark' ||
-      picked === 'postfix' ||
-      picked === 'emailit' ||
-      picked === 'mock'
-    )
+    if (picked === 'postmark' || picked === 'postfix' || picked === 'emailit' || picked === 'mock')
       return picked;
   } catch (err) {
     // DB unreachable (boot race, maintenance window). Fall through to env so

--- a/apps/server/src/db/migrations/20260518000001_email_provider_emailit.js
+++ b/apps/server/src/db/migrations/20260518000001_email_provider_emailit.js
@@ -1,0 +1,22 @@
+/**
+ * Adds 'emailit' to the email_provider enum so admins can pick Emailit
+ * (https://emailit.com — v2 transactional API) from the Admin → Settings
+ * dropdown. The bridge ships with a matching EmailitProvider; selecting it
+ * without storing email.emailit.api_key first is blocked by the pre-flight
+ * check in PATCH /admin/settings.
+ *
+ * Postgres 12+ allows ALTER TYPE … ADD VALUE inside a transaction so long
+ * as the new value isn't used in the same transaction — which is the case
+ * here (no row writes 'emailit' yet). IF NOT EXISTS guards the down-then-up
+ * dev case.
+ */
+exports.up = async function up(knex) {
+  await knex.raw(`ALTER TYPE email_provider ADD VALUE IF NOT EXISTS 'emailit'`);
+};
+
+// Postgres has no DROP VALUE for enums. Rolling back requires recreating
+// the type without 'emailit' and rewriting every column that uses it —
+// overkill for a forward-only enum extension. The down() is a no-op; a
+// fresh DB built from migrations re-applies up() and ends in the same
+// state, which is what matters.
+exports.down = async function down() {};

--- a/apps/server/src/env.ts
+++ b/apps/server/src/env.ts
@@ -148,11 +148,23 @@ export const env = {
   // response shape is preserved so the absence isn't probe-able). The
   // db-backed `firm_settings.email_provider` enum doesn't include 'none'
   // — flipping the override here is the only way to disable mail wholesale.
-  emailProvider: str('EMAIL_PROVIDER', 'mock') as 'mock' | 'postmark' | 'postfix' | 'none',
+  emailProvider: str('EMAIL_PROVIDER', 'mock') as
+    | 'mock'
+    | 'postmark'
+    | 'postfix'
+    | 'emailit'
+    | 'none',
   emailFrom: str('EMAIL_FROM', 'Vibe Connect <noreply@vibeconnect.local>'),
   emailInboundDomain: str('EMAIL_INBOUND_DOMAIN', 'connect.vibeconnect.local'),
   postmarkServerToken: str('POSTMARK_SERVER_TOKEN', ''),
   postmarkInboundWebhookSecret: str('POSTMARK_INBOUND_WEBHOOK_SECRET', ''),
+  // Emailit (https://emailit.com) — transactional email v2 API. API key is
+  // the only required credential; base URL defaults to api.emailit.com/v2
+  // and is only here so a future regional endpoint can be selected from
+  // the Admin UI without a code change.
+  emailitApiKey: str('EMAILIT_API_KEY', ''),
+  emailitBaseUrl: str('EMAILIT_BASE_URL', ''),
+  emailitReplyTo: str('EMAILIT_REPLY_TO', ''),
   // Dedicated secret for the Postfix pipe's raw-MIME endpoint. Previously
   // this shared POSTMARK_INBOUND_WEBHOOK_SECRET, which meant a leaked
   // Postmark bounce/error revealing the secret also opened the raw endpoint.

--- a/apps/server/src/routes/admin.ts
+++ b/apps/server/src/routes/admin.ts
@@ -132,7 +132,7 @@ const settingsSchema = z.object({
   emailOutboundContentPreviewChars: z.number().int().min(0).max(2000).optional(),
   smsProvider: z.enum(['textlink', 'twilio', 'mock']).optional(),
   smsMonthlyCap: z.number().int().min(0).max(100_000).optional(),
-  emailProvider: z.enum(['mock', 'postmark', 'postfix']).optional(),
+  emailProvider: z.enum(['mock', 'postmark', 'postfix', 'emailit']).optional(),
   exportExternalRequiresRecoveryPhrase: z.boolean().optional(),
   sidebarGroupsOrder: z.array(z.string().uuid()).optional(),
   // 0 = never lock; upper bound matches the DB constraint (24 h).
@@ -280,6 +280,7 @@ function normalizeAdminUrl(
 const REQUIRED_SECRETS_BY_PROVIDER: Record<string, ProviderSecretKey[]> = {
   postmark: ['email.postmark.server_token'],
   postfix: ['email.smtp.host', 'email.smtp.port'],
+  emailit: ['email.emailit.api_key'],
   textlink: ['sms.textlink.api_key'],
   twilio: ['sms.twilio.account_sid', 'sms.twilio.auth_token'],
   // 'mock' providers write to the local .outbox/ and never need secrets.

--- a/apps/server/src/services/providerSecrets.ts
+++ b/apps/server/src/services/providerSecrets.ts
@@ -46,6 +46,10 @@ export const PROVIDER_SECRET_KEYS = [
   'email.smtp.user',
   'email.smtp.pass',
   'email.smtp.secure',
+  // --- Email — Emailit (https://emailit.com v2 API) ---
+  'email.emailit.api_key',
+  'email.emailit.base_url',
+  'email.emailit.reply_to',
 ] as const;
 export type ProviderSecretKey = (typeof PROVIDER_SECRET_KEYS)[number];
 const KEY_SET: ReadonlySet<string> = new Set(PROVIDER_SECRET_KEYS);
@@ -60,6 +64,8 @@ const NON_SECRET_KEYS: ReadonlySet<ProviderSecretKey> = new Set([
   'email.smtp.host',
   'email.smtp.port',
   'email.smtp.secure',
+  'email.emailit.base_url',
+  'email.emailit.reply_to',
 ]);
 export function isMaskedKey(key: ProviderSecretKey): boolean {
   return !NON_SECRET_KEYS.has(key);

--- a/apps/web/src/components/InviteClientModal.tsx
+++ b/apps/web/src/components/InviteClientModal.tsx
@@ -61,6 +61,10 @@ export interface InviteCreatedResult {
   displayName: string;
   invitePublicKey: string;
   deliveryStatus: { email: 'sent' | 'failed' | null; sms: 'sent' | 'failed' | null };
+  /** Provider error string surfaced when deliveryStatus.* === 'failed'. The
+   *  invite toast renders this so SMTP / API failures don't hide behind a
+   *  generic "email failed". */
+  deliveryErrors?: { email?: string; sms?: string };
   /** True when the modal ran in resend mode and re-dispatched an invite. */
   resent?: boolean;
 }
@@ -362,6 +366,7 @@ export function InviteClientModal({
           displayName: displayName.trim(),
           invitePublicKey: resent.invitePublicKey,
           deliveryStatus: resent.deliveryStatus,
+          deliveryErrors: resent.deliveryErrors,
           resent: true,
         });
         return;
@@ -391,6 +396,7 @@ export function InviteClientModal({
         displayName: displayName.trim(),
         invitePublicKey: invite.invitePublicKey,
         deliveryStatus: invite.deliveryStatus,
+        deliveryErrors: invite.deliveryErrors,
       });
     } catch (err) {
       // `json()` in api.ts throws Error with { status, body } attached. Pull the

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1105,13 +1105,20 @@ export function Sidebar(): JSX.Element {
           const sms = result.deliveryStatus.sms;
           const parts: string[] = [];
           if (email === 'sent') parts.push('email sent');
-          else if (email === 'failed') parts.push('email failed');
+          else if (email === 'failed') {
+            const reason = result.deliveryErrors?.email?.slice(0, 140);
+            parts.push(reason ? `email failed (${reason})` : 'email failed');
+          }
           if (sms === 'sent') parts.push('SMS sent');
-          else if (sms === 'failed') parts.push('SMS failed');
+          else if (sms === 'failed') {
+            const reason = result.deliveryErrors?.sms?.slice(0, 140);
+            parts.push(reason ? `SMS failed (${reason})` : 'SMS failed');
+          }
           setResendFlash(
             `Re-invited ${result.displayName}${parts.length > 0 ? ` — ${parts.join(', ')}` : ''}.`,
           );
-          window.setTimeout(() => setResendFlash(null), 6_000);
+          const hasFailure = email === 'failed' || sms === 'failed';
+          window.setTimeout(() => setResendFlash(null), hasFailure ? 20_000 : 6_000);
         }}
         onOpenExistingClient={(clientId, clientDisplayName) => {
           // 409 on resend means email/phone now collide with another identity.

--- a/apps/web/src/pages/Admin.tsx
+++ b/apps/web/src/pages/Admin.tsx
@@ -997,7 +997,7 @@ function AdminSettings(): JSX.Element {
     stepup_timeout_hours: number;
     email_outbound_mode: 'summary' | 'content';
     sms_provider: 'textlink' | 'twilio' | 'mock';
-    email_provider: 'mock' | 'postmark' | 'postfix';
+    email_provider: 'mock' | 'postmark' | 'postfix' | 'emailit';
     idle_lock_minutes: number;
     client_messaging_enabled: boolean;
     requests_enabled: boolean;
@@ -1329,6 +1329,7 @@ function AdminSettings(): JSX.Element {
           <option value="mock">Mock (dev only — writes to .outbox/)</option>
           <option value="postmark">Postmark (transactional)</option>
           <option value="postfix">SMTP / Postfix (self-hosted relay)</option>
+          <option value="emailit">Emailit (transactional)</option>
         </select>
         <span className="mt-1 text-[11px] text-slate-500 block">
           Configure credentials in <strong>Admin → Providers</strong> before switching off Mock.
@@ -1951,14 +1952,22 @@ export function AdminClients(): JSX.Element {
           const sms = result.deliveryStatus.sms;
           const parts: string[] = [];
           if (email === 'sent') parts.push('email sent');
-          else if (email === 'failed') parts.push('email failed');
+          else if (email === 'failed') {
+            const reason = result.deliveryErrors?.email?.slice(0, 140);
+            parts.push(reason ? `email failed (${reason})` : 'email failed');
+          }
           if (sms === 'sent') parts.push('SMS sent');
-          else if (sms === 'failed') parts.push('SMS failed');
+          else if (sms === 'failed') {
+            const reason = result.deliveryErrors?.sms?.slice(0, 140);
+            parts.push(reason ? `SMS failed (${reason})` : 'SMS failed');
+          }
           setFlash(
             `Invited ${result.displayName}${parts.length > 0 ? ` — ${parts.join(', ')}` : ''}.`,
           );
-          // Self-clear so the row's normal "pending" state takes over.
-          window.setTimeout(() => setFlash(null), 6_000);
+          // Failures get a longer dwell so admins can read the underlying
+          // provider error before it disappears — success self-clears fast.
+          const hasFailure = email === 'failed' || sms === 'failed';
+          window.setTimeout(() => setFlash(null), hasFailure ? 20_000 : 6_000);
         }}
         onOpenExistingClient={(_clientId, existingName) => {
           // Duplicate path — the admin /clients search matches on name /
@@ -3358,6 +3367,26 @@ const PROVIDER_GROUPS: {
         key: 'email.smtp.secure',
         label: 'TLS (1 = on, 0 = off)',
         placeholder: '1',
+        inputType: 'text',
+      },
+    ],
+  },
+  {
+    title: 'Email — Emailit',
+    blurb:
+      'Used when EMAIL_PROVIDER=emailit. Transactional v2 API (emailit.com). API key is the only required field; the base URL defaults to https://api.emailit.com/v2.',
+    keys: [
+      { key: 'email.emailit.api_key', label: 'API key', placeholder: 'Emailit API key' },
+      {
+        key: 'email.emailit.base_url',
+        label: 'Base URL (optional)',
+        placeholder: 'https://api.emailit.com/v2',
+        inputType: 'text',
+      },
+      {
+        key: 'email.emailit.reply_to',
+        label: 'Reply-To (optional)',
+        placeholder: 'reply@yourfirm.com',
         inputType: 'text',
       },
     ],


### PR DESCRIPTION
## Summary

- Adds **Emailit** (https://emailit.com — v2 transactional API) as a 4th email provider alongside `mock` / `postmark` / `postfix`. Ported from the production client in `Vibe-Payroll-Time` so the v1-URL / object-from / array-of-object-to mistakes that bit a sibling project on first integration don't repeat here.
- Fixes the invite "email failed" toast to **show the underlying SMTP / API error** instead of just "email failed". Same applies to SMS. Toast dwell is bumped to 20s on failure so admins can actually read the message.

## What ships

| Layer | Change |
|---|---|
| Migration | `ALTER TYPE email_provider ADD VALUE 'emailit'` (forward-only, no-op down) |
| Provider secrets | New registry keys `email.emailit.{api_key, base_url, reply_to}` (api_key masked, the others shown as plaintext UI fields) |
| Bridge | `EmailitProvider` class: POST `https://api.emailit.com/v2/emails`, Bearer auth, RFC 5322 `from`, 15s timeout, redacted error body |
| Resolver | `getEmailProvider()` returns `EmailitProvider` when `firm_settings.email_provider = 'emailit'` |
| Pre-flight | Switching to `emailit` is rejected with `provider_secrets_missing` until `email.emailit.api_key` is stored |
| Admin UI | New "Email — Emailit" card in **Admin → Providers** + `Emailit (transactional)` option in the email provider dropdown |
| Invite toast | When `deliveryStatus.email === 'failed'`, toast renders `email failed (<actual error>)` truncated to 140 chars; 20s dwell on failure, 6s on success. Same for SMS. Applies to both `Admin.tsx` (Create-client) and `Sidebar.tsx` (Resend-invite) flows. |

## Test plan

- [x] `yarn typecheck` clean across server + web
- [x] `yarn lint` clean (0 warnings)
- [x] `yarn test` server: **240 passed** (7 in `provider-selection`, 4 new `emailit-provider`)
- [x] `yarn workspace @vibe-connect/web test`: 21 passed
- [x] `yarn workspace @vibe-connect/web build` clean
- [x] `yarn workspace @vibe-connect/server build` clean
- [ ] Manual smoke after merge + tag: store a real Emailit API key in Admin → Providers, flip provider to Emailit, send a client invite, confirm the message lands and the toast says "email sent"
- [ ] Manual smoke for the toast: with a deliberately broken SMTP profile (wrong port / wrong password), send an invite and confirm the toast surfaces the underlying SMTP error string

🤖 Generated with [Claude Code](https://claude.com/claude-code)