### PR TITLE
fix(bridges): harden email + SMS error handling, timeouts, audit gaps

### DIFF
--- a/apps/server/src/__tests__/emailit-provider.test.ts
+++ b/apps/server/src/__tests__/emailit-provider.test.ts
@@ -106,6 +106,49 @@ describe('EmailitProvider', () => {
     );
   });
 
+  it('redacts long dash-free tokens but preserves UUID-shaped correlation IDs', async () => {
+    // The redact regex must drop bearer-token-shaped runs (20+ chars,
+    // dash-free) while leaving UUIDs readable so operators can file
+    // provider support tickets with the correlation ID in hand.
+    const { set } = await import('../services/providerSecrets.js');
+    await set('email.emailit.api_key', 'test-key', null);
+    const body =
+      '{"error":"invalid_token","leaked":"abcdefghijklmnopqrstuvwxyz1234567890","traceId":"12345678-1234-1234-1234-123456789012"}';
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(body, { status: 401, headers: { 'content-type': 'application/json' } }),
+    );
+
+    const { getEmailProvider } = await import('../bridges/email/index.js');
+    const provider = await getEmailProvider();
+    try {
+      await provider.send({ to: 'a@b.com', subject: 's', text: 't' });
+      throw new Error('expected throw');
+    } catch (err) {
+      const msg = (err as Error).message;
+      expect(msg).toMatch(/emailit_401/);
+      // Bearer-shaped token gone:
+      expect(msg).not.toContain('abcdefghijklmnopqrstuvwxyz1234567890');
+      // UUID preserved:
+      expect(msg).toContain('12345678-1234-1234-1234-123456789012');
+    }
+  });
+
+  it('maps fetch timeout to a typed emailit_timeout error', async () => {
+    const { set } = await import('../services/providerSecrets.js');
+    await set('email.emailit.api_key', 'test-key', null);
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(() => {
+      const e = new DOMException('aborted', 'TimeoutError');
+      return Promise.reject(e);
+    });
+
+    const { getEmailProvider } = await import('../bridges/email/index.js');
+    const provider = await getEmailProvider();
+    await expect(provider.send({ to: 'a@b.com', subject: 's', text: 't' })).rejects.toThrow(
+      /emailit_timeout_after_\d+ms/,
+    );
+  });
+
   it('throws when api_key is missing', async () => {
     // No secret stored, env fallback also empty (tests start with EMAILIT_API_KEY unset).
     const { getEmailProvider } = await import('../bridges/email/index.js');

--- a/apps/server/src/__tests__/postfix-provider.test.ts
+++ b/apps/server/src/__tests__/postfix-provider.test.ts
@@ -1,0 +1,65 @@
+/**
+ * PostfixProvider — guards around the SMTP send path that the e2e test
+ * suites don't exercise (they all run against the mock provider). Covers
+ * the partial-auth XOR refusal so a typo in Admin → Providers doesn't
+ * silently fall back to an unauthenticated relay session.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { resetTestDb } from './test-helpers.js';
+
+beforeAll(async () => {
+  process.env.NODE_ENV = 'test';
+  process.env.DATABASE_URL =
+    process.env.TEST_DATABASE_URL ?? 'postgres://vibe:vibe@localhost:5435/vibe_connect_test';
+  await resetTestDb();
+});
+
+beforeEach(async () => {
+  const { db } = await import('../db/knex.js');
+  await db('firm_provider_credentials').del();
+  await db('firm_settings').where({ id: 1 }).update({ email_provider: 'postfix' });
+});
+
+describe('PostfixProvider', () => {
+  it('refuses to build a transport when only smtp.user is configured', async () => {
+    const { set } = await import('../services/providerSecrets.js');
+    await set('email.smtp.host', 'smtp.example.com', null);
+    await set('email.smtp.port', '587', null);
+    await set('email.smtp.user', 'alice@example.com', null);
+    // intentionally NO email.smtp.pass
+
+    const { getEmailProvider } = await import('../bridges/email/index.js');
+    const provider = await getEmailProvider();
+    expect(provider.name).toBe('postfix');
+    await expect(provider.send({ to: 'a@b.com', subject: 's', text: 't' })).rejects.toThrow(
+      /smtp_partial_auth_configured/,
+    );
+  });
+
+  it('refuses to build a transport when only smtp.pass is configured', async () => {
+    const { set } = await import('../services/providerSecrets.js');
+    await set('email.smtp.host', 'smtp.example.com', null);
+    await set('email.smtp.port', '587', null);
+    await set('email.smtp.pass', 'p@ssw0rd', null);
+    // intentionally NO email.smtp.user
+
+    const { getEmailProvider } = await import('../bridges/email/index.js');
+    const provider = await getEmailProvider();
+    await expect(provider.send({ to: 'a@b.com', subject: 's', text: 't' })).rejects.toThrow(
+      /smtp_partial_auth_configured/,
+    );
+  });
+
+  it('throws SMTP_HOST is required when host is missing', async () => {
+    const { getEmailProvider } = await import('../bridges/email/index.js');
+    const provider = await getEmailProvider();
+    await expect(provider.send({ to: 'a@b.com', subject: 's', text: 't' })).rejects.toThrow(
+      /SMTP_HOST is required/,
+    );
+  });
+});
+
+afterAll(async () => {
+  const { db } = await import('../db/knex.js');
+  await db.destroy();
+});

--- a/apps/server/src/__tests__/sms-providers.test.ts
+++ b/apps/server/src/__tests__/sms-providers.test.ts
@@ -1,0 +1,125 @@
+/**
+ * SMS provider (Twilio + TextLink) error / timeout / redaction tests with
+ * fetch stubbed. Locks the contract that:
+ *   - Timeouts surface as a typed `<provider>_timeout_after_*ms` error
+ *     rather than hanging the caller until Node's default idle window.
+ *   - Long dash-free tokens get redacted from error bodies while
+ *     UUID-shaped correlation IDs stay readable.
+ *   - The full body is logged at warn level so operators tailing
+ *     docker logs see provider correlation info we strip from the throw.
+ */
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resetTestDb } from './test-helpers.js';
+
+beforeAll(async () => {
+  process.env.NODE_ENV = 'test';
+  process.env.DATABASE_URL =
+    process.env.TEST_DATABASE_URL ?? 'postgres://vibe:vibe@localhost:5435/vibe_connect_test';
+  await resetTestDb();
+});
+
+beforeEach(async () => {
+  const { db } = await import('../db/knex.js');
+  await db('firm_provider_credentials').del();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('TextLink SMS', () => {
+  beforeEach(async () => {
+    const { db } = await import('../db/knex.js');
+    await db('firm_settings').where({ id: 1 }).update({ sms_provider: 'textlink' });
+    const { set } = await import('../services/providerSecrets.js');
+    await set('sms.textlink.api_key', 'test-tl-key', null);
+  });
+
+  it('maps timeout to textlink_timeout_after_*ms', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+      Promise.reject(new DOMException('aborted', 'TimeoutError')),
+    );
+    const { getSmsProvider } = await import('../bridges/sms/index.js');
+    const provider = await getSmsProvider();
+    await expect(provider.sendMessage({ to: '+15551234567', body: 'hi' })).rejects.toThrow(
+      /textlink_timeout_after_\d+ms/,
+    );
+  });
+
+  it('redacts long dash-free tokens but preserves UUIDs in 4xx body', async () => {
+    const body =
+      '{"err":"bad","key":"abcdefghijklmnopqrstuvwxyz1234567890","traceId":"12345678-1234-1234-1234-123456789012"}';
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(body, { status: 401, headers: { 'content-type': 'application/json' } }),
+    );
+    const { getSmsProvider } = await import('../bridges/sms/index.js');
+    const provider = await getSmsProvider();
+    try {
+      await provider.sendMessage({ to: '+15551234567', body: 'hi' });
+      throw new Error('expected throw');
+    } catch (err) {
+      const msg = (err as Error).message;
+      expect(msg).toMatch(/textlink_401/);
+      expect(msg).not.toContain('abcdefghijklmnopqrstuvwxyz1234567890');
+      expect(msg).toContain('12345678-1234-1234-1234-123456789012');
+    }
+  });
+});
+
+describe('Twilio SMS', () => {
+  beforeEach(async () => {
+    const { db } = await import('../db/knex.js');
+    await db('firm_settings').where({ id: 1 }).update({ sms_provider: 'twilio' });
+    const { set } = await import('../services/providerSecrets.js');
+    await set('sms.twilio.account_sid', 'ACtestSIDplaceholderNOTREALxxxxxxxx', null);
+    await set('sms.twilio.auth_token', 'tw-test-token', null);
+    await set('sms.twilio.from_number', '+15550001111', null);
+  });
+
+  it('maps timeout to twilio_timeout_after_*ms', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+      Promise.reject(new DOMException('aborted', 'TimeoutError')),
+    );
+    const { getSmsProvider } = await import('../bridges/sms/index.js');
+    const provider = await getSmsProvider();
+    await expect(provider.sendMessage({ to: '+15551234567', body: 'hi' })).rejects.toThrow(
+      /twilio_timeout_after_\d+ms/,
+    );
+  });
+
+  it('redacts Account SID from 4xx body but keeps the error message readable', async () => {
+    const body =
+      '{"code":21408,"message":"Permission denied for ACtestSIDplaceholderNOTREALxxxxxxxx","more_info":"https://www.twilio.com/docs/errors/21408"}';
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(body, { status: 400, headers: { 'content-type': 'application/json' } }),
+    );
+    const { getSmsProvider } = await import('../bridges/sms/index.js');
+    const provider = await getSmsProvider();
+    try {
+      await provider.sendMessage({ to: '+15551234567', body: 'hi' });
+      throw new Error('expected throw');
+    } catch (err) {
+      const msg = (err as Error).message;
+      expect(msg).toMatch(/twilio_400/);
+      // The Twilio SID got redacted (dash-free, 34 chars):
+      expect(msg).not.toContain('ACtestSIDplaceholderNOTREALxxxxxxxx');
+      // The non-secret error description survives:
+      expect(msg.toLowerCase()).toContain('permission denied');
+    }
+  });
+
+  it('throws twilio_credentials_not_configured when account_sid is missing', async () => {
+    const { db } = await import('../db/knex.js');
+    await db('firm_provider_credentials').where({ key: 'sms.twilio.account_sid' }).del();
+    const { getSmsProvider } = await import('../bridges/sms/index.js');
+    const provider = await getSmsProvider();
+    await expect(provider.sendMessage({ to: '+15551234567', body: 'hi' })).rejects.toThrow(
+      /twilio_credentials_not_configured/,
+    );
+  });
+});
+
+afterAll(async () => {
+  const { db } = await import('../db/knex.js');
+  await db.destroy();
+});

--- a/apps/server/src/bridges/email/index.ts
+++ b/apps/server/src/bridges/email/index.ts
@@ -15,6 +15,31 @@ export interface EmailMessage {
   replyTo?: string;
 }
 
+// Single timeout used by every HTTP-based provider. 15s comfortably covers
+// the p99 of Postmark / Emailit / Twilio while still letting a stuck send
+// surface as a logged failure rather than blocking a ticker tick forever.
+const PROVIDER_TIMEOUT_MS = 15_000;
+
+// Hard-cap + best-effort redact for provider error bodies before they
+// flow into thrown errors. The contiguous-alnum pattern catches dash-free
+// tokens (Twilio Account SIDs, hex API keys, base64 secrets) without
+// shredding UUID-shaped correlation IDs (which contain dashes — operators
+// need them visible to file support tickets).
+function redactAndCap(raw: string): string {
+  const redacted = raw.replace(/[A-Za-z0-9_]{20,}/g, '[redacted]');
+  // 160 chars keeps the toast on one or two lines and bounds the audit
+  // detail size — operators who need the full payload have it in the
+  // warn log emitted by the provider call site.
+  return redacted.length > 160 ? `${redacted.slice(0, 160)}…` : redacted;
+}
+
+function mapFetchError(provider: string, err: unknown): Error {
+  const isTimeout = err instanceof DOMException && err.name === 'TimeoutError';
+  if (isTimeout) return new Error(`${provider}_timeout_after_${PROVIDER_TIMEOUT_MS}ms`);
+  const msg = err instanceof Error ? err.message : String(err);
+  return new Error(`${provider}_network_error: ${msg.slice(0, 120)}`);
+}
+
 export interface EmailProvider {
   send(msg: EmailMessage): Promise<{ id: string; status: 'sent' | 'queued' | 'bounced' }>;
   name: string;
@@ -67,21 +92,29 @@ class PostmarkProvider implements EmailProvider {
       ReplyTo: msg.replyTo,
       MessageStream: 'outbound',
     };
-    const res = await fetch('https://api.postmarkapp.com/email', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Accept: 'application/json',
-        'X-Postmark-Server-Token': token,
-      },
-      body: JSON.stringify(body),
-    });
+    let res: Response;
+    try {
+      res = await fetch('https://api.postmarkapp.com/email', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+          'X-Postmark-Server-Token': token,
+        },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(PROVIDER_TIMEOUT_MS),
+      });
+    } catch (err) {
+      throw mapFetchError('postmark', err);
+    }
     if (!res.ok) {
-      // Postmark returns the token in error replies for some 4xx cases. Strip
-      // any bearer-like substrings from the body before surfacing — we don't
-      // want credentials to land in audit details via the bridge's error path.
-      const txt = (await res.text()).replace(/[A-Za-z0-9-]{20,}/g, '[redacted]');
-      throw new Error(`postmark_${res.status}: ${txt}`);
+      // Postmark returns the token in error replies for some 4xx cases. We
+      // log the full body at warn level so operators tailing docker logs
+      // can see correlation IDs / Postmark error codes, then bubble a hard
+      // -capped + redacted form upward (audit + UI toast).
+      const full = await res.text();
+      logger.warn('email.postmark_send_failed', { status: res.status, body: full.slice(0, 500) });
+      throw new Error(`postmark_${res.status}: ${redactAndCap(full)}`);
     }
     const data = (await res.json()) as { MessageID: string };
     return { id: data.MessageID, status: 'sent' as const };
@@ -97,7 +130,6 @@ class PostmarkProvider implements EmailProvider {
 //   * `to` is a string or string[], not an [{email}] array.
 //   * Auth is Bearer <api_key>.
 const DEFAULT_EMAILIT_BASE_URL = 'https://api.emailit.com/v2';
-const EMAILIT_TIMEOUT_MS = 15_000;
 class EmailitProvider implements EmailProvider {
   name = 'emailit';
   async send(msg: EmailMessage) {
@@ -133,21 +165,15 @@ class EmailitProvider implements EmailProvider {
           accept: 'application/json',
         },
         body: JSON.stringify(body),
-        signal: AbortSignal.timeout(EMAILIT_TIMEOUT_MS),
+        signal: AbortSignal.timeout(PROVIDER_TIMEOUT_MS),
       });
     } catch (err) {
-      const isTimeout = err instanceof DOMException && err.name === 'TimeoutError';
-      throw new Error(
-        isTimeout
-          ? `emailit_timeout_after_${EMAILIT_TIMEOUT_MS}ms`
-          : `emailit_network_error: ${err instanceof Error ? err.message : String(err)}`,
-      );
+      throw mapFetchError('emailit', err);
     }
     if (!res.ok) {
-      // Strip anything that looks like a bearer token from the body before
-      // surfacing it — matches the redaction posture of PostmarkProvider.
-      const txt = (await res.text()).replace(/[A-Za-z0-9_-]{24,}/g, '[redacted]');
-      throw new Error(`emailit_${res.status}: ${txt.slice(0, 200)}`);
+      const full = await res.text();
+      logger.warn('email.emailit_send_failed', { status: res.status, body: full.slice(0, 500) });
+      throw new Error(`emailit_${res.status}: ${redactAndCap(full)}`);
     }
     let parsed: unknown = null;
     try {
@@ -185,6 +211,15 @@ class PostfixProvider implements EmailProvider {
     const secure = secureFlag === '1' || secureFlag === 'true';
     const user = await getOrEnvFallback('email.smtp.user', env.smtpUser);
     const pass = await getOrEnvFallback('email.smtp.pass', env.smtpPass);
+    // Half-configured auth (user without pass or vice-versa) is almost
+    // always a config typo — silently falling back to an unauthenticated
+    // session lets the send "succeed" against a relay that will then drop
+    // or spam-tag the message. Refuse loudly so the admin sees the gap.
+    if (Boolean(user) !== Boolean(pass)) {
+      throw new Error(
+        'smtp_partial_auth_configured: both email.smtp.user and email.smtp.pass must be set together',
+      );
+    }
     return nodemailer.createTransport({
       host,
       port,

--- a/apps/server/src/bridges/sms/index.ts
+++ b/apps/server/src/bridges/sms/index.ts
@@ -41,6 +41,26 @@ export interface SmsProvider {
   verifyWebhookSignature(ctx: WebhookVerifyContext): Promise<boolean> | boolean;
 }
 
+// Same timeout posture as the email bridge — never let a stuck provider
+// call hang a ticker tick or a route handler. Twilio + TextLink both
+// respond well under 15s in normal operation.
+const SMS_PROVIDER_TIMEOUT_MS = 15_000;
+
+// Best-effort redact of long dash-free alphanumeric runs (Twilio Account
+// SIDs, hex API keys) without shredding UUID-shaped correlation IDs.
+// Operators get the full body via the warn log emitted at the call site.
+function redactAndCapSms(raw: string): string {
+  const redacted = raw.replace(/[A-Za-z0-9_]{20,}/g, '[redacted]');
+  return redacted.length > 160 ? `${redacted.slice(0, 160)}…` : redacted;
+}
+
+function mapSmsFetchError(provider: string, err: unknown): Error {
+  const isTimeout = err instanceof DOMException && err.name === 'TimeoutError';
+  if (isTimeout) return new Error(`${provider}_timeout_after_${SMS_PROVIDER_TIMEOUT_MS}ms`);
+  const msg = err instanceof Error ? err.message : String(err);
+  return new Error(`${provider}_network_error: ${msg.slice(0, 120)}`);
+}
+
 class MockSms implements SmsProvider {
   name = 'mock' as const;
   async sendMessage(req: SmsSendRequest) {
@@ -76,12 +96,22 @@ class TextLinkSms implements SmsProvider {
   async sendMessage(req: SmsSendRequest) {
     const apiKey = await getOrEnvFallback('sms.textlink.api_key', env.textlinkApiKey);
     if (!apiKey) throw new Error('textlink_api_key_not_configured');
-    const res = await fetch('https://textlinksms.com/api/send-sms', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ apiKey, to: req.to, message: req.body }),
-    });
-    if (!res.ok) throw new Error(`textlink_${res.status}`);
+    let res: Response;
+    try {
+      res = await fetch('https://textlinksms.com/api/send-sms', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ apiKey, to: req.to, message: req.body }),
+        signal: AbortSignal.timeout(SMS_PROVIDER_TIMEOUT_MS),
+      });
+    } catch (err) {
+      throw mapSmsFetchError('textlink', err);
+    }
+    if (!res.ok) {
+      const full = await res.text();
+      logger.warn('sms.textlink_send_failed', { status: res.status, body: full.slice(0, 500) });
+      throw new Error(`textlink_${res.status}: ${redactAndCapSms(full)}`);
+    }
     const data = (await res.json()) as { messageId?: string };
     return { id: data.messageId ?? crypto.randomUUID(), status: 'sent' as const };
   }
@@ -140,20 +170,24 @@ class TwilioSms implements SmsProvider {
     if (messagingServiceSid) form.set('MessagingServiceSid', messagingServiceSid);
     else if (fromNumber) form.set('From', fromNumber);
     const auth = Buffer.from(`${accountSid}:${authToken}`).toString('base64');
-    const res = await fetch(url, {
-      method: 'POST',
-      headers: {
-        Authorization: `Basic ${auth}`,
-        'Content-Type': 'application/x-www-form-urlencoded',
-      },
-      body: form.toString(),
-    });
+    let res: Response;
+    try {
+      res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          Authorization: `Basic ${auth}`,
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: form.toString(),
+        signal: AbortSignal.timeout(SMS_PROVIDER_TIMEOUT_MS),
+      });
+    } catch (err) {
+      throw mapSmsFetchError('twilio', err);
+    }
     if (!res.ok) {
-      // Twilio surfaces the account SID in error payloads. Strip any 20+ char
-      // alnum runs before bubbling so we never leak token-shaped material
-      // into upstream error logs / audit details.
-      const txt = (await res.text()).replace(/[A-Za-z0-9]{20,}/g, '[redacted]');
-      throw new Error(`twilio_${res.status}: ${txt}`);
+      const full = await res.text();
+      logger.warn('sms.twilio_send_failed', { status: res.status, body: full.slice(0, 500) });
+      throw new Error(`twilio_${res.status}: ${redactAndCapSms(full)}`);
     }
     const data = (await res.json()) as { sid: string };
     return { id: data.sid, status: 'sent' as const };

--- a/apps/server/src/services/intakeClientNotifyTicker.ts
+++ b/apps/server/src/services/intakeClientNotifyTicker.ts
@@ -210,8 +210,17 @@ async function processOne(row: ClaimedNotificationRow): Promise<void> {
       },
       ipAddress: null,
     })
-    .catch(() => {
-      /* audit failure shouldn't fail the send */
+    .catch((err) => {
+      // Audit failure must not fail the send (the message went out), but
+      // silently swallowing leaves a gap in the audit table that looks
+      // identical to "never sent". One warn line so docker-logs forensics
+      // can correlate the audit-table gap to the actual send.
+      logger.warn('intake.client_notify_audit_write_failed', {
+        rowId: row.id,
+        sessionId: row.session_id,
+        channel: row.channel,
+        err: err instanceof Error ? err.message : String(err),
+      });
     });
   logger.info('intake.client_notify_sent', {
     rowId: row.id,
@@ -274,8 +283,11 @@ async function markFailed(row: ClaimedNotificationRow, reason: string): Promise<
       },
       ipAddress: null,
     })
-    .catch(() => {
-      /* audit failure shouldn't loop the retry */
+    .catch((err) => {
+      logger.warn('intake.client_notify_failure_audit_write_failed', {
+        rowId: row.id,
+        err: err instanceof Error ? err.message : String(err),
+      });
     });
   logger.error('intake.client_notify_permanent_failure', {
     rowId: row.id,

--- a/apps/server/src/services/intakeStaffNotifyTicker.ts
+++ b/apps/server/src/services/intakeStaffNotifyTicker.ts
@@ -198,8 +198,14 @@ async function processOne(row: StaffRow): Promise<void> {
       },
       ipAddress: null,
     })
-    .catch(() => {
-      /* audit failure shouldn't fail the send */
+    .catch((err) => {
+      // Send succeeded; audit-table gap would otherwise look identical to
+      // "never sent" — log so forensics can correlate.
+      logger.warn('intake.staff_notify_audit_write_failed', {
+        rowId: row.id,
+        channel: row.channel,
+        err: err instanceof Error ? err.message : String(err),
+      });
     });
   logger.info('intake.staff_notify_sent', {
     rowId: row.id,
@@ -498,8 +504,11 @@ async function flushDigests(): Promise<void> {
           },
           ipAddress: null,
         })
-        .catch(() => {
-          /* audit failure shouldn't fail send */
+        .catch((err) => {
+          logger.warn('intake.staff_notify_digest_audit_write_failed', {
+            userId,
+            err: err instanceof Error ? err.message : String(err),
+          });
         });
       logger.info('intake.staff_notify_digest_sent', {
         userId,
@@ -552,8 +561,11 @@ async function markFailed(row: StaffRow, reason: string): Promise<void> {
       },
       ipAddress: null,
     })
-    .catch(() => {
-      /* audit failure shouldn't loop */
+    .catch((err) => {
+      logger.warn('intake.staff_notify_failure_audit_write_failed', {
+        rowId: row.id,
+        err: err instanceof Error ? err.message : String(err),
+      });
     });
   logger.error('intake.staff_notify_permanent_failure', {
     rowId: row.id,


### PR DESCRIPTION
## Summary

QA pass on every outbound email / SMS provider path. Six concrete improvements, all local to the bridge code or the intake tickers — no contract or schema changes.

## What ships

### Timeouts everywhere
- 15s `AbortSignal.timeout` on Postmark, Twilio, TextLink fetch calls (Emailit already had one; now uses a shared constant).
- Timeouts surface as `<provider>_timeout_after_15000ms` instead of hanging until Node's default idle window. Critical for ticker ticks — previously one stuck send could block the whole tick.

### Better redaction
- `redactAndCap()` (email) and `redactAndCapSms()` (SMS) replace per-provider regexes. The pattern drops dash-free 20+ char runs (Twilio Account SIDs, hex / base64 secrets) but **preserves UUID-shaped correlation IDs** so operators can match them to provider dashboards. Hard 160-char cap.
- Every non-2xx response is logged to `logger.warn` with the first 500 chars of the body BEFORE redaction, so docker-logs forensics has the full payload even though the throw is trimmed.

### PostfixProvider XOR auth guard
- Throw `smtp_partial_auth_configured` when only one of `email.smtp.user` / `email.smtp.pass` is set. Previously nodemailer silently dropped auth entirely; on many relays this sends unauthenticated and gets dropped or spam-tagged with no signal to the admin.

### Audit-failure visibility in tickers
- `intakeClientNotifyTicker` and `intakeStaffNotifyTicker` still don't fail the send when an audit row fails to write (the message already went out), but they no longer silently swallow. One `logger.warn` per miss so an audit-table gap is distinguishable from "never sent".

### Tests
- `emailit-provider.test.ts`: +2 cases — redaction preserves UUIDs, timeout → typed error.
- `postfix-provider.test.ts` (new): 3 cases — XOR-auth refusal, host-required.
- `sms-providers.test.ts` (new): 5 cases — Twilio + TextLink timeout mapping, SID redaction with UUID preservation, missing-credentials throws.
- Full suite: **243 server / 21 web**, all green. Lint, format-check, typecheck all green.

## Findings the subagent surfaced but I did NOT ship

These need product judgment or are bigger architectural changes. Documenting here for your decision:

- **Twilio From/MessagingServiceSid pre-flight**. Current behavior: if both are configured, MessagingServiceSid wins (Twilio's documented behavior). If neither, Twilio returns 400 and we surface it. Subagent wanted a hard pre-flight in `PATCH /admin/settings`. Cheap to add, but the current behavior is correct — would prevent a misconfig, not a bug.
- **Quiet-hours / DND bounds validation**. The zod schema on `PATCH /admin/settings` should bound `sms_quiet_*_hour` to 0–23. Need to verify whether it already does before adding.
- **Permanent vs transient error categorization in tickers**. A 401 currently gets the same 1m/5m/15m backoff as a 503. Architectural change — fail-fast on 401/403, longer backoff on 429, normal on 5xx.
- **Twilio HMAC signature `Buffer.from(sig, 'utf8')`**. Subagent flagged this; on re-read it's a non-issue — base64 strings are pure ASCII so UTF-8 encoding is byte-identical and `timingSafeEqual` requires equal-length buffers (which they are).
- **Per-message PII scrubbing extension** (emails / phones / SSNs in error strings). Theoretical; provider errors today are structured JSON without recipient PII.
- **TextLink missing-signature-header explicit log**. Current behavior already returns `false` so the webhook gets 401'd. One extra warn line would help triage but is low value.

## Test plan

- [x] `yarn typecheck`, `yarn lint`, `yarn format:check` clean
- [x] `yarn workspace @vibe-connect/server test`: 243 passed
- [x] `yarn workspace @vibe-connect/web test`: 21 passed
- [x] `yarn workspace @vibe-connect/server build`, `@vibe-connect/web build` clean
- [ ] Manual smoke after merge + tag: deliberately misconfigure SMTP (port mismatch, wrong pass, partial auth) and confirm the invite toast surfaces a useful error instead of generic "email failed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)