### PR TITLE
fix(nginx): bare /intake fell through to the catch-all SPA

### DIFF
--- a/infra/docker/nginx/nginx.conf.template
+++ b/infra/docker/nginx/nginx.conf.template
@@ -191,7 +191,14 @@ http {
       # search /usr/share/nginx/html/intake/intake/index.html which doesn't
       # exist.)
       rewrite ^/intake/?(.*)$ /$1 break;
-      try_files $uri $uri/ /index.html;
+      # Do NOT include `$uri/` in this try_files: when the rewrite collapses
+      # the URI to bare `/`, nginx finds the intake root as a directory and
+      # internal-redirects to `/` — which then falls through to the catch-all
+      # `location /` below (the staff bundle, or the portal bundle on the
+      # portal block) and the visitor lands on the wrong app. Skipping the
+      # directory check makes nginx fall straight to `/index.html` which the
+      # current `root` directive resolves under `/usr/share/nginx/html/intake/`.
+      try_files $uri /index.html;
       # Phase 28.17 — substitute __BASE_HREF__ inside the PWA manifest as
       # well as the HTML shell, so start_url / scope resolve correctly in
       # both single-app and multi-app modes from one build.
@@ -288,7 +295,11 @@ http {
     location ^~ /intake {
       root /usr/share/nginx/html/intake;
       rewrite ^/intake/?(.*)$ /$1 break;
-      try_files $uri $uri/ /index.html;
+      # See the staff /intake block above for why `$uri/` is omitted —
+      # without this, a bare `/intake` request internal-redirects to `/`
+      # and the portal catch-all below answers, dumping the portal SPA
+      # at the visitor (whose React Router then bounces them to /login).
+      try_files $uri /index.html;
       sub_filter_types application/manifest+json;
       sub_filter '__BASE_HREF__' '${PORTAL_BASE_PATH_HREF}';
       sub_filter_once off;
@@ -416,7 +427,10 @@ http {
       }
       root /usr/share/nginx/html/intake;
       rewrite ^/intake/?(.*)$ /$1 break;
-      try_files $uri $uri/ /index.html;
+      # See the staff TLS-internal /intake block for why `$uri/` is omitted
+      # from try_files — bare `/intake` otherwise internal-redirects to `/`
+      # and the catch-all answers with the wrong bundle.
+      try_files $uri /index.html;
       # nginx's default already includes text/html; this only ADDS
       # application/manifest+json so PWA manifests get __BASE_HREF__
       # substituted alongside the HTML shell.
@@ -500,7 +514,11 @@ http {
     location ^~ /intake {
       root /usr/share/nginx/html/intake;
       rewrite ^/intake/?(.*)$ /$1 break;
-      try_files $uri $uri/ /index.html;
+      # See the staff /intake block above for why `$uri/` is omitted —
+      # without this, a bare `/intake` request internal-redirects to `/`
+      # and the portal catch-all below answers, dumping the portal SPA
+      # at the visitor (whose React Router then bounces them to /login).
+      try_files $uri /index.html;
       sub_filter_types application/manifest+json;
       sub_filter '__BASE_HREF__' '${PORTAL_BASE_PATH_HREF}';
       sub_filter_once off;


### PR DESCRIPTION
## The bug

User reported: visiting `https://clients.<domain>/intake` redirected to the client login page instead of showing the intake landing.

After live diagnostics, the report drops out of a chain in the nginx config:

1. Request `/intake` matches `^~ /intake` ✓
2. `rewrite ^/intake/?(.*)$ /$1 break;` rewrites URI to `/`
3. `try_files \$uri \$uri/ /index.html`:
   - `\$uri` = `/` → looks up `/usr/share/nginx/html/intake/` — that's a directory, not a file. Skip.
   - **`\$uri/` = `/` → directory exists.** nginx issues an **internal redirect to `/`**.
4. Internal redirect re-runs location matching. `/` no longer matches `^~ /intake`. It matches **`location /`** (the catch-all). On the portal listener, that serves `/usr/share/nginx/html/portal/index.html`.
5. Portal SPA boots. Its React Router has `<Route path="*" element={<Navigate to="/" replace />} />`. `/intake` doesn't match any portal route → bounced to `/` → `IdentifyPage` (client login).

Deep links like `/intake/<staffId>` and `/intake/t/<token>` worked because the rewritten URI (`/<staffId>`) wasn't a directory on disk, so the `\$uri/` check missed and the `/index.html` fallback fired correctly.

## The fix

Drop `\$uri/` from the four `^~ /intake` blocks (staff TLS-internal, portal TLS-internal, shared HTTP default_server, portal-http external). Standard SPA-fallback pattern — we never wanted directory auto-indexing here, only `<root>/index.html` as the React shell.

`location /` catch-alls retain `try_files \$uri \$uri/ /index.html` — the internal redirect lands on the **same** location, so it's idempotent.

## Repro (in the wild)

```bash
docker exec vibe-connect-client sh -c \
  "curl -sI -H 'Host: clients.example.com' http://localhost:8080/intake | head -3"
# Before fix: 200 → portal bundle's index.html with <title>Firm Portal</title>
# After fix:  200 → intake bundle's index.html with <title>Send files</title>
```

## Test plan

- [x] Format check + lint clean
- [ ] After merge + tag, redeploy on the appliance and confirm `clients.<domain>/intake` shows the intake Landing instead of the portal login

🤖 Generated with [Claude Code](https://claude.com/claude-code)