### PR TITLE
fix(boot): basePath "/" produced // URLs and dropped the host

### DIFF
--- a/apps/intake/src/lib/boot.ts
+++ b/apps/intake/src/lib/boot.ts
@@ -48,7 +48,13 @@ export function getBoot(): VibeBoot {
 export function url(path: string): string {
   if (/^[a-z]+:\/\//i.test(path) || path.startsWith('//')) return path;
   const base = getBoot().basePath;
-  if (!base) return path.startsWith('/') ? path : '/' + path;
+  // `base === '/'` collapses to the root-mount case: `base + '/api/foo'`
+  // would otherwise emit `//api/foo`, which a browser parses as a
+  // protocol-relative URL and tries to DNS-resolve `api`. Defensive
+  // belt-and-suspenders against an older server returning `/` for the
+  // root-mount basePath (the bootstrap was changed to emit `""` instead,
+  // but this SPA may be served from a stale appliance).
+  if (!base || base === '/') return path.startsWith('/') ? path : '/' + path;
   const p = path.startsWith('/') ? path : '/' + path;
   return base + p;
 }

--- a/apps/portal/src/lib/boot.ts
+++ b/apps/portal/src/lib/boot.ts
@@ -36,7 +36,11 @@ export function getBoot(): VibeBoot {
 export function url(path: string): string {
   if (/^[a-z]+:\/\//i.test(path) || path.startsWith('//')) return path;
   const base = getBoot().basePath;
-  if (!base) return path.startsWith('/') ? path : '/' + path;
+  // `base === '/'` collapses to the root-mount case: `base + '/api/foo'`
+  // would otherwise emit `//api/foo`, which a browser parses as a
+  // protocol-relative URL. Defensive guard alongside the server-side
+  // bootstrap fix that now emits `""` instead of `"/"`.
+  if (!base || base === '/') return path.startsWith('/') ? path : '/' + path;
   const p = path.startsWith('/') ? path : '/' + path;
   return base + p;
 }

--- a/apps/server/src/__tests__/url-override.test.ts
+++ b/apps/server/src/__tests__/url-override.test.ts
@@ -73,6 +73,18 @@ async function readBoot(): Promise<{ siteUrl: string; portalUrl: string }> {
   return JSON.parse(match[1]!) as { siteUrl: string; portalUrl: string };
 }
 
+// Same as readBoot but with a configurable Host header — exercises the
+// host-aware basePath derivation in routes/bootstrap.ts.
+async function readBootWithHost(
+  host: string,
+): Promise<{ basePath: string; siteUrl: string; portalUrl: string }> {
+  const r = await request(app).get('/__vibe-boot.js').set('Host', host);
+  expect(r.status).toBe(200);
+  const match = /window\.__VIBE_BOOT__ = (\{[\s\S]*\});/.exec(r.text);
+  if (!match) throw new Error(`unexpected boot payload: ${r.text}`);
+  return JSON.parse(match[1]!) as { basePath: string; siteUrl: string; portalUrl: string };
+}
+
 describe('effectiveUrls() helper', () => {
   it('falls back to env when DB columns are null', async () => {
     const { effectiveUrls } = await import('../services/effectiveUrls.js');
@@ -166,6 +178,29 @@ describe('PATCH /admin/settings — URL validation', () => {
       .patch('/admin/settings')
       .send({ siteUrl: 'https://vibe.cpa2web.app/connect' });
     expect(r.status).toBe(403);
+  });
+});
+
+describe('Host-aware basePath derivation', () => {
+  it('emits basePath="" (not "/") when the Host matches a root-mounted portal URL', async () => {
+    // CRITICAL regression guard: the apps/{web,portal,intake}/lib/boot.ts
+    // url() helper does `base + path`. If the server returns basePath="/"
+    // for a root-mounted host, the helper produces "//api/foo", which a
+    // browser parses as protocol-relative and tries to DNS-resolve `api`
+    // — the entire staff/client list fetch dies with ERR_NAME_NOT_RESOLVED.
+    // Empty string is the right value here; React Router accepts "" as a
+    // basename and url() short-circuits on falsy base.
+    const admin = await loginAs('kurt', 'kurt-dev-only-ChangeMe!');
+    await admin.patch('/admin/settings').send({
+      siteUrl: 'https://vibe.cpa2web.app/connect',
+      portalUrl: 'https://client.cpa2web.app',
+    });
+
+    const portalBoot = await readBootWithHost('client.cpa2web.app');
+    expect(portalBoot.basePath).toBe('');
+
+    const staffBoot = await readBootWithHost('vibe.cpa2web.app');
+    expect(staffBoot.basePath).toBe('/connect');
   });
 });
 

--- a/apps/server/src/routes/bootstrap.ts
+++ b/apps/server/src/routes/bootstrap.ts
@@ -55,11 +55,15 @@ function basePathForRequest(req: Request, urls: EffectiveUrls): string {
       const parsed = new URL(url);
       if (parsed.host === reqHost) {
         // URL.pathname for a hostname-only URL is "/" — strip the trailing
-        // slash so the SPA's router gets a consistent shape ("" for root,
-        // "/connect" for prefixed). Fall back to "/" for the rare case
-        // where the trim leaves an empty string and downstream code can't
-        // handle "" — React Router treats "" and "/" equivalently here.
-        return parsed.pathname.replace(/\/$/, '') || '/';
+        // slash so the SPA's router gets a consistent shape: "" for the
+        // root-mounted case and "/connect" (no trailing slash) for the
+        // prefixed case. MUST NOT fall back to "/" when the strip leaves
+        // an empty string — the SPA's url() helper does `base + path` and
+        // would emit "/" + "/api/foo" = "//api/foo", which a browser
+        // interprets as a protocol-relative URL with `api` as the host.
+        // Empty string is the right value here; React Router accepts it
+        // as a basename and `url()` short-circuits on falsy base.
+        return parsed.pathname.replace(/\/$/, '');
       }
     } catch {
       // Malformed URL in env or DB — skip this candidate and try the next.

--- a/apps/web/src/lib/__tests__/boot.test.ts
+++ b/apps/web/src/lib/__tests__/boot.test.ts
@@ -111,6 +111,24 @@ describe('url() — absolute URL passthrough (any mode)', () => {
   });
 });
 
+describe('url() — basePath "/" defensive guard', () => {
+  // The server-side bootstrap now emits basePath="" (empty) for root-mounted
+  // hosts, but an older appliance could still hand back basePath="/" via a
+  // cached __vibe-boot.js. Without the guard the helper would do
+  // `"/" + "/api/foo"` = `"//api/foo"`, which a browser parses as
+  // protocol-relative and tries to DNS-resolve `api`.
+  it('treats basePath="/" the same as basePath="" (no protocol-relative output)', () => {
+    setBoot({ basePath: '/' });
+    expect(url('/api/public/intake/staff')).toBe('/api/public/intake/staff');
+    expect(url('/auth/login')).toBe('/auth/login');
+  });
+
+  it('prepends a slash to relative paths when basePath="/"', () => {
+    setBoot({ basePath: '/' });
+    expect(url('auth/login')).toBe('/auth/login');
+  });
+});
+
 describe('url() — defensive cases that should not happen in practice', () => {
   it('does not double-prepend when caller already includes BASE_PATH', () => {
     // This IS a footgun: callers must NOT pass a pre-prefixed path. The

--- a/apps/web/src/lib/boot.ts
+++ b/apps/web/src/lib/boot.ts
@@ -48,7 +48,11 @@ export function getBoot(): VibeBoot {
 export function url(path: string): string {
   if (/^[a-z]+:\/\//i.test(path) || path.startsWith('//')) return path;
   const base = getBoot().basePath;
-  if (!base) return path.startsWith('/') ? path : '/' + path;
+  // `base === '/'` collapses to the root-mount case: `base + '/api/foo'`
+  // would otherwise emit `//api/foo`, which a browser parses as a
+  // protocol-relative URL. Defensive guard alongside the server-side
+  // bootstrap fix that now emits `""` instead of `"/"`.
+  if (!base || base === '/') return path.startsWith('/') ? path : '/' + path;
   const p = path.startsWith('/') ? path : '/' + path;
   return base + p;
 }


### PR DESCRIPTION
## The bug

Fresh /intake landing on a client-subdomain deployment: the staff card grid fails with `net::ERR_NAME_NOT_RESOLVED` on `//api/public/intake/staff`. Browser tried to fetch the path against hostname `api`. Server logs show no inbound request — the fetch died in the browser.

Chain:

1. `basePathForRequest` in `routes/bootstrap.ts` returns `"/"` when the matched portal/site URL's pathname is `/` (the previous comment claimed "React Router treats `""` and `"/"` equivalently" — true for Router, NOT for URL construction).
2. `apps/{web,portal,intake}/lib/boot.ts:url()` does `base + path`. With `base = "/"` and `path = "/api/public/intake/staff"`, the result is `"/" + "/api/public/intake/staff"` = `"//api/public/intake/staff"`.
3. Browser parses the leading `//` as protocol-relative → `https://api/public/intake/staff` → DNS fails.

The portal SPA's login page worked because rendering it requires no fetches; the bug surfaced on the first API call.

## Fix

Two changes, defensive together:

- **`bootstrap.ts`**: return `""` (empty) instead of `"/"`. Empty string is the right shape for a root-mounted host — React Router accepts it as a basename, and `url()` short-circuits on falsy base.

- **`url()` in all three SPAs**: treat `"/"` the same as `""`. Server-side is the root fix; this guard catches a stale appliance serving a cached `__vibe-boot.js` (we cap that response at 60s max-age but it can still race a fresh SPA bundle).

## Regression tests

- `url-override.test.ts`: hitting `/__vibe-boot.js` with `Host: client.cpa2web.app` asserts `basePath === ""` (not `"/"`) for the root-mounted portal URL, while the staff `Host: vibe.cpa2web.app` still gets `"/connect"`.
- `web/lib/__tests__/boot.test.ts`: `url()` with `basePath="/"` produces single-slash output for both leading-slash and bare paths.

## Test plan

- [x] yarn typecheck + lint + format clean
- [x] 243 server tests + 23 web tests pass
- [ ] After v0.4.13 redeploy, `client.cpa2web.app/intake` loads the staff card grid (Kurt Krueger card visible per the production curl)

🤖 Generated with [Claude Code](https://claude.com/claude-code)