### PR TITLE
fix(intake): embed any image-mime upload in the assembled PDF + add file preview

### DIFF
--- a/apps/server/src/__tests__/intake-pdf-conversion.test.ts
+++ b/apps/server/src/__tests__/intake-pdf-conversion.test.ts
@@ -217,6 +217,28 @@ describe('Phase 28.9 — PDF conversion ticker', () => {
     expect(pdfRow.page_count).toBe(3);
   });
 
+  it('also embeds image-mime files uploaded as kind=file (iOS native-camera path)', async () => {
+    // Regression guard for the iPhone Safari report where a single
+    // IMG_*.jpeg taken via the OS camera fallback arrived as kind='file'
+    // and the assembled PDF was cover-page-only (1.5 KB) with the image
+    // listed under "Other files attached" instead of as a PDF page.
+    // The builder now embeds any file whose mime_type starts with
+    // image/, regardless of kind.
+    const { sessionId, token } = await createSession();
+    const jpeg = await makeJpeg();
+    await uploadFile(token, jpeg, {
+      filename: 'IMG_3127.jpeg',
+      filetype: 'image/jpeg',
+      // intentionally no `kind` — defaults to 'file' on the server,
+      // mirroring the apps/intake fallback path.
+    });
+    const { id } = await processSession(sessionId);
+    const pdfRow = await db('intake_pdfs').where({ id }).first();
+    expect(pdfRow.conversion_status).toBe('done');
+    // Cover + 1 image page = 2 pages. Previously: 1 (cover only).
+    expect(pdfRow.page_count).toBe(2);
+  });
+
   it('honours firm_settings.intake_include_cover_page=false', async () => {
     const { sessionId, token } = await createSession();
     await db('firm_settings').where({ id: 1 }).update({ intake_include_cover_page: false });

--- a/apps/server/src/routes/intakeAdmin.ts
+++ b/apps/server/src/routes/intakeAdmin.ts
@@ -16,6 +16,7 @@
 import { createHash, randomBytes } from 'node:crypto';
 import { Router } from 'express';
 import rateLimit from 'express-rate-limit';
+import sharp from 'sharp';
 import { z } from 'zod';
 import { db } from '../db/knex.js';
 import { logger } from '../logger.js';
@@ -358,6 +359,68 @@ intakeAdminRouter.get(
     );
     res.setHeader('X-Content-Type-Options', 'nosniff');
     res.send(plaintext);
+  }),
+);
+
+// -------- file thumbnail (image preview) --------
+//
+// Returns a small JPEG preview for image-mime intake files so the staff
+// session-detail UI can render thumbnails inline next to each row. The
+// underlying bytes are encrypted at rest with the firm intake key; we
+// decrypt in-process, downsample with sharp, and return a fresh JPEG.
+// No audit row — this fires once per page render and would otherwise
+// drown out actual download events. Cache-Control of 5min lets the
+// browser reuse the response across re-renders.
+intakeAdminRouter.get(
+  '/sessions/:id/files/:fileId/thumbnail',
+  requireAuth,
+  asyncHandler(async (req, res) => {
+    const sessionId = req.params.id!;
+    const fileId = req.params.fileId!;
+    const session = await intakeSessionsRepo.byId(sessionId);
+    if (!session) {
+      res.status(404).json({ error: 'not_found' });
+      return;
+    }
+    if (!req.session.isAdmin && session.staff_id !== req.session.userId) {
+      res.status(403).json({ error: 'forbidden' });
+      return;
+    }
+    const file = await intakeFilesRepo.byId(fileId);
+    if (!file || file.session_id !== sessionId) {
+      res.status(404).json({ error: 'not_found' });
+      return;
+    }
+    const mime = (file.mime_type ?? '').toLowerCase();
+    if (file.kind !== 'scanned_image' && !mime.startsWith('image/')) {
+      // Non-image files have no inline thumbnail — caller should hide
+      // the <img> element rather than ever requesting this URL.
+      res.status(404).json({ error: 'not_image' });
+      return;
+    }
+    try {
+      const ciphertext = await attachmentStorage().get(file.stored_path);
+      const plaintext = await decryptBufferStreaming(ciphertext);
+      // 192 px on the long edge × 2x DPR = sharp on retina. JPEG at q70
+      // — readable at thumbnail size, ~5–15 KB on typical phone photos.
+      const thumb = await sharp(plaintext)
+        .rotate()
+        .resize({ width: 192, height: 192, fit: 'inside' })
+        .jpeg({ quality: 70 })
+        .toBuffer();
+      res.setHeader('Content-Type', 'image/jpeg');
+      res.setHeader('Content-Length', String(thumb.length));
+      res.setHeader('Cache-Control', 'private, max-age=300');
+      res.setHeader('X-Content-Type-Options', 'nosniff');
+      res.send(thumb);
+    } catch (err) {
+      logger.warn('intake.thumbnail_failed', {
+        sessionId,
+        fileId,
+        msg: err instanceof Error ? err.message : String(err),
+      });
+      res.status(500).json({ error: 'thumbnail_failed' });
+    }
   }),
 );
 

--- a/apps/server/src/services/intakePdfBuilder.ts
+++ b/apps/server/src/services/intakePdfBuilder.ts
@@ -79,8 +79,17 @@ export async function buildPdfForSession(sessionId: string): Promise<BuildPdfRes
     throw new Error(`buildPdfForSession: session ${sessionId} not found`);
   }
   const files = await intakeFilesRepo.listBySession(sessionId);
-  const scannedImages = files.filter((f) => f.kind === 'scanned_image');
-  const otherFiles = files.filter((f) => f.kind === 'file');
+  // Every image-mime upload becomes an embedded PDF page, regardless of
+  // whether it arrived through the in-browser scanner (kind='scanned_image')
+  // or through the regular file picker / iOS native-camera fallback
+  // (kind='file' with an image/* mime). Originally we only embedded
+  // kind='scanned_image' rows, which left clients-who-took-a-photo with a
+  // cover-only PDF and their image listed in "Other files attached" —
+  // surprising for the staff recipient who expected one mergeable PDF.
+  const isEmbeddable = (f: IntakeFileRow): boolean =>
+    f.kind === 'scanned_image' || (f.mime_type ?? '').toLowerCase().startsWith('image/');
+  const scannedImages = files.filter(isEmbeddable);
+  const otherFiles = files.filter((f) => !isEmbeddable(f));
 
   const staff = await db('users')
     .where({ id: session.staff_id })

--- a/apps/web/src/pages/Admin.tsx
+++ b/apps/web/src/pages/Admin.tsx
@@ -5048,27 +5048,55 @@ function AdminIntakeDetail({
             <section className="space-y-2">
               <h4 className="font-medium text-slate-900">Files ({detailQ.data.files.length})</h4>
               <ul className="space-y-1">
-                {detailQ.data.files.map((f) => (
-                  <li
-                    key={f.id}
-                    className="flex items-center justify-between border border-slate-100 rounded p-2"
-                  >
-                    <div className="min-w-0 flex-1">
-                      <div className="truncate text-slate-900">{f.originalFilename}</div>
-                      <div className="text-xs text-slate-500">
-                        {f.kind === 'scanned_image' ? 'Scanned image' : 'File'} ·{' '}
-                        {formatIntakeBytes(f.sizeBytes)}
-                      </div>
-                    </div>
-                    <a
-                      href={appUrl(`/admin/intake/sessions/${sessionId}/files/${f.id}`)}
-                      className="text-xs text-brand-700 hover:text-brand-800"
-                      download
+                {detailQ.data.files.map((f) => {
+                  const isImage =
+                    f.kind === 'scanned_image' ||
+                    (f.mimeType ?? '').toLowerCase().startsWith('image/');
+                  return (
+                    <li
+                      key={f.id}
+                      className="flex items-center gap-3 border border-slate-100 rounded p-2"
                     >
-                      Download
-                    </a>
-                  </li>
-                ))}
+                      {/* Inline thumbnail for image-mime files. The route
+                          decrypts + downsamples + caches; non-image rows
+                          show a generic placeholder so the layout stays
+                          aligned. */}
+                      {isImage ? (
+                        <img
+                          src={appUrl(
+                            `/admin/intake/sessions/${sessionId}/files/${f.id}/thumbnail`,
+                          )}
+                          alt=""
+                          width={48}
+                          height={48}
+                          className="w-12 h-12 rounded object-cover bg-slate-100 border border-slate-200 flex-shrink-0"
+                          loading="lazy"
+                        />
+                      ) : (
+                        <div
+                          aria-hidden="true"
+                          className="w-12 h-12 rounded bg-slate-100 border border-slate-200 flex items-center justify-center text-slate-400 text-xs flex-shrink-0"
+                        >
+                          File
+                        </div>
+                      )}
+                      <div className="min-w-0 flex-1">
+                        <div className="truncate text-slate-900">{f.originalFilename}</div>
+                        <div className="text-xs text-slate-500">
+                          {f.kind === 'scanned_image' ? 'Scanned image' : 'File'} ·{' '}
+                          {formatIntakeBytes(f.sizeBytes)}
+                        </div>
+                      </div>
+                      <a
+                        href={appUrl(`/admin/intake/sessions/${sessionId}/files/${f.id}`)}
+                        className="text-xs text-brand-700 hover:text-brand-800"
+                        download
+                      >
+                        Download
+                      </a>
+                    </li>
+                  );
+                })}
               </ul>
             </section>
             {/* Phase 28.15 — retention status + admin override. */}


### PR DESCRIPTION
## Two reports from the same iPhone Safari session

### 1. Image not embedded in the assembled PDF

A 2.4 MB IMG_3127.jpeg came back assembled as a **1.5 KB PDF** — the cover page rendered but the image was never embedded. The image appeared under the cover's "Other files attached" list instead of as a PDF page.

**Root cause:** the capture had landed via the iOS native-camera fallback (`<input capture>`), which writes `kind='file'` to `intake_files` — not `kind='scanned_image'`. The Phase 28.9 PDF builder filter only embedded `scanned_image` rows, so image-mime uploads via the file picker fell through to the "Other files" list.

**Fix:** `intakePdfBuilder.ts` now embeds any file whose mime_type is `image/*`, regardless of kind. Sharp's pipeline already normalises HEIC / EXIF orientation / etc, so no other change needed. PDF / docx / etc still go into "Other files attached" on the cover page.

Regression test: `intake-pdf-conversion.test.ts` gains a `kind='file' + image/jpeg` case asserting `page_count === 2` (cover + image). Before the fix that landed at 1.

### 2. "Can we add a preview image on the tab?"

The staff session-detail panel's Files (N) list showed only filenames + sizes.

**Fix:** new `GET /admin/intake/sessions/:id/files/:fileId/thumbnail` route — decrypts with the firm intake key, downsamples to 192 px on the long edge via sharp, returns a fresh JPEG with `Cache-Control: private, max-age=300`. No audit row (would otherwise drown out actual download events).

Admin.tsx renders the thumbnail inline for image-mime rows. Non-image rows show a "File" placeholder so column alignment stays clean.

## Test plan

- [x] typecheck + lint + format clean
- [x] 244 server tests pass (243 prior + 1 new regression)
- [ ] After v0.4.15 redeploy:
  - [ ] Send an iPhone-camera photo via the intake portal — confirm the assembled PDF is now 2+ pages, cover + image
  - [ ] Open the staff session-detail panel — confirm the file row shows a thumbnail preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)