### PR TITLE
feat(admin): per-provider Test buttons in Admin → Providers

### DIFF
--- a/apps/server/src/__tests__/provider-selection.test.ts
+++ b/apps/server/src/__tests__/provider-selection.test.ts
@@ -134,6 +134,70 @@ describe('DB-backed provider selection', () => {
     const read = await admin.get('/admin/settings');
     expect(read.body.settings.email_provider).toBe('emailit');
   });
+
+  describe('Admin → Providers test endpoints', () => {
+    it('POST /admin/providers/test/email rejects with provider_secrets_missing when emailit has no api_key', async () => {
+      const { db } = await import('../db/knex.js');
+      await db('firm_provider_credentials').delete();
+      const admin = await loginAs('kurt', 'kurt-dev-only-ChangeMe!');
+      const res = await admin
+        .post('/admin/providers/test/email')
+        .send({ provider: 'emailit', to: 'admin@example.com' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('provider_secrets_missing');
+      expect(res.body.keys).toEqual(['email.emailit.api_key']);
+    });
+
+    it('POST /admin/providers/test/sms rejects with provider_secrets_missing when textlink has no api_key', async () => {
+      const { db } = await import('../db/knex.js');
+      await db('firm_provider_credentials').delete();
+      const admin = await loginAs('kurt', 'kurt-dev-only-ChangeMe!');
+      const res = await admin
+        .post('/admin/providers/test/sms')
+        .send({ provider: 'textlink', to: '+15551234567' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('provider_secrets_missing');
+    });
+
+    it('POST /admin/providers/test/email with mock provider always succeeds + writes audit row', async () => {
+      const admin = await loginAs('kurt', 'kurt-dev-only-ChangeMe!');
+      const res = await admin
+        .post('/admin/providers/test/email')
+        .send({ provider: 'mock', to: 'admin@example.com' });
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.providerMessageId).toMatch(/^mock-/);
+      // Audit row should land.
+      const { db } = await import('../db/knex.js');
+      const row = await db('audit_log')
+        .where({ action: 'admin.provider_test_sent' })
+        .orderBy('created_at', 'desc')
+        .first();
+      expect(row).toBeDefined();
+      expect(row.details.provider).toBe('mock');
+      expect(row.details.status).toBe('sent');
+    });
+
+    it('rejects validation errors (bad email, bad provider enum)', async () => {
+      const admin = await loginAs('kurt', 'kurt-dev-only-ChangeMe!');
+      const bad1 = await admin
+        .post('/admin/providers/test/email')
+        .send({ provider: 'emailit', to: 'not-an-email' });
+      expect(bad1.status).toBe(400);
+      const bad2 = await admin
+        .post('/admin/providers/test/email')
+        .send({ provider: 'sendgrid', to: 'admin@example.com' });
+      expect(bad2.status).toBe(400);
+    });
+
+    it('non-admin (staff) is forbidden from hitting the test endpoint', async () => {
+      const alice = await loginAs('alice', 'alice-dev-only-ChangeMe!');
+      const res = await alice
+        .post('/admin/providers/test/email')
+        .send({ provider: 'mock', to: 'admin@example.com' });
+      expect(res.status).toBe(403);
+    });
+  });
 });
 
 afterAll(async () => {

--- a/apps/server/src/bridges/email/index.ts
+++ b/apps/server/src/bridges/email/index.ts
@@ -276,6 +276,37 @@ async function resolveEmailProviderKind(): Promise<
   return env.emailProvider;
 }
 
+export type EmailProviderKind = 'mock' | 'postmark' | 'postfix' | 'emailit' | 'none';
+
+/**
+ * Factory for a SPECIFIC provider, bypassing the resolver. Used by the
+ * Admin → Providers "Test" button so an admin can verify a provider's
+ * credentials are working before flipping `firm_settings.email_provider`
+ * to it (otherwise testing a new provider would require flipping the
+ * setting first, taking outbound mail with it on failure).
+ */
+export function buildEmailProvider(kind: EmailProviderKind): EmailProvider {
+  switch (kind) {
+    case 'postmark':
+      return new PostmarkProvider();
+    case 'postfix':
+      return new PostfixProvider();
+    case 'emailit':
+      return new EmailitProvider();
+    case 'none':
+      return new NoneProvider();
+    case 'mock':
+    default:
+      return new MockProvider();
+  }
+}
+
+/** What the resolver currently picks. Exposed so Admin → Providers can
+ *  surface "Emailit (active)" vs "Postmark (configured but not active)". */
+export async function currentEmailProviderKind(): Promise<EmailProviderKind> {
+  return resolveEmailProviderKind();
+}
+
 export async function getEmailProvider(): Promise<EmailProvider> {
   switch (await resolveEmailProviderKind()) {
     case 'postmark':

--- a/apps/server/src/bridges/sms/index.ts
+++ b/apps/server/src/bridges/sms/index.ts
@@ -249,8 +249,12 @@ async function resolveSmsProviderKind(): Promise<'mock' | 'textlink' | 'twilio'>
   return env.smsProvider;
 }
 
-export async function getSmsProvider(): Promise<SmsProvider> {
-  switch (await resolveSmsProviderKind()) {
+export type SmsProviderKind = 'mock' | 'textlink' | 'twilio';
+
+/** Factory for a SPECIFIC SMS provider, bypassing the resolver. Used by
+ *  the Admin → Providers "Test" button. See bridges/email for rationale. */
+export function buildSmsProvider(kind: SmsProviderKind): SmsProvider {
+  switch (kind) {
     case 'textlink':
       return new TextLinkSms();
     case 'twilio':
@@ -259,4 +263,12 @@ export async function getSmsProvider(): Promise<SmsProvider> {
     default:
       return new MockSms();
   }
+}
+
+export async function currentSmsProviderKind(): Promise<SmsProviderKind> {
+  return resolveSmsProviderKind();
+}
+
+export async function getSmsProvider(): Promise<SmsProvider> {
+  return buildSmsProvider(await resolveSmsProviderKind());
 }

--- a/apps/server/src/routes/admin.ts
+++ b/apps/server/src/routes/admin.ts
@@ -1505,6 +1505,138 @@ adminRouter.delete(
   }),
 );
 
+// ---------- Provider test send ----------
+//
+// Admin → Providers exposes a "Test" button per provider. The button
+// POSTs here with the specific provider kind + a recipient address; the
+// server instantiates THAT provider (not the currently-resolved one) and
+// sends a small fixed test message. Returns the provider's reported
+// message id on success or the error string on failure — both are echoed
+// in the UI so the admin can immediately see what's wrong with their
+// credentials. Audit-logged so a compromise leaves a trail.
+//
+// Rate-limited tightly: a test send is an outbound API call to a paid
+// provider; we don't want a stuck UI / bug to drain the firm's quota.
+const providerTestSendLimiter = rateLimit({
+  windowMs: 10 * 60 * 1000,
+  limit: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+const testEmailBody = z.object({
+  provider: z.enum(['postmark', 'postfix', 'emailit', 'mock']),
+  to: z.string().email().max(254),
+});
+
+adminRouter.post(
+  '/providers/test/email',
+  requireAdmin,
+  providerTestSendLimiter,
+  asyncHandler(async (req, res) => {
+    const parsed = testEmailBody.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: 'validation', details: parsed.error.flatten() });
+      return;
+    }
+    const { provider, to } = parsed.data;
+    const gap = await missingSecretsFor(provider);
+    if (gap.length > 0) {
+      res.status(400).json({ error: 'provider_secrets_missing', keys: gap });
+      return;
+    }
+    const { buildEmailProvider } = await import('../bridges/email/index.js');
+    const impl = buildEmailProvider(provider);
+    const stamp = new Date().toISOString();
+    try {
+      const result = await impl.send({
+        to,
+        subject: 'Vibe Connect — test email',
+        text: `This is a test email from Vibe Connect's Admin → Providers diagnostic.\n\nProvider: ${provider}\nSent at: ${stamp}\n\nIf you received this, ${provider} is configured correctly.`,
+      });
+      await auditRepo.write({
+        actorUserId: req.session.userId!,
+        action: 'admin.provider_test_sent',
+        targetType: 'firm_settings',
+        targetId: 'email',
+        details: { provider, status: 'sent', messageId: result.id },
+        ipAddress: req.ip ?? null,
+      });
+      res.json({ ok: true, providerMessageId: result.id, status: result.status });
+    } catch (err) {
+      const reason = (err instanceof Error ? err.message : String(err)).slice(0, 400);
+      await auditRepo.write({
+        actorUserId: req.session.userId!,
+        action: 'admin.provider_test_sent',
+        targetType: 'firm_settings',
+        targetId: 'email',
+        details: { provider, status: 'failed', reason: reason.slice(0, 200) },
+        ipAddress: req.ip ?? null,
+      });
+      res.status(502).json({ ok: false, error: reason });
+    }
+  }),
+);
+
+const testSmsBody = z.object({
+  provider: z.enum(['twilio', 'textlink', 'mock']),
+  to: z
+    .string()
+    .min(7)
+    .max(20)
+    .regex(/^\+?[0-9\s\-()]+$/, 'must look like a phone number'),
+});
+
+adminRouter.post(
+  '/providers/test/sms',
+  requireAdmin,
+  providerTestSendLimiter,
+  asyncHandler(async (req, res) => {
+    const parsed = testSmsBody.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: 'validation', details: parsed.error.flatten() });
+      return;
+    }
+    const { provider, to } = parsed.data;
+    const gap = await missingSecretsFor(provider);
+    if (gap.length > 0) {
+      res.status(400).json({ error: 'provider_secrets_missing', keys: gap });
+      return;
+    }
+    const { buildSmsProvider } = await import('../bridges/sms/index.js');
+    const impl = buildSmsProvider(provider);
+    const stamp = new Date().toISOString().slice(0, 16).replace('T', ' ');
+    // E.164 normalisation: strip spaces / dashes / parens; ensure leading +.
+    const normalisedTo = to.replace(/[\s\-()]/g, '').replace(/^(?!\+)/, '+');
+    try {
+      const result = await impl.sendMessage({
+        to: normalisedTo,
+        body: `Vibe Connect test SMS via ${provider} at ${stamp} UTC. If you received this, the provider is configured correctly. Reply STOP to opt out.`,
+      });
+      await auditRepo.write({
+        actorUserId: req.session.userId!,
+        action: 'admin.provider_test_sent',
+        targetType: 'firm_settings',
+        targetId: 'sms',
+        details: { provider, status: 'sent', messageId: result.id },
+        ipAddress: req.ip ?? null,
+      });
+      res.json({ ok: true, providerMessageId: result.id, status: result.status });
+    } catch (err) {
+      const reason = (err instanceof Error ? err.message : String(err)).slice(0, 400);
+      await auditRepo.write({
+        actorUserId: req.session.userId!,
+        action: 'admin.provider_test_sent',
+        targetType: 'firm_settings',
+        targetId: 'sms',
+        details: { provider, status: 'failed', reason: reason.slice(0, 200) },
+        ipAddress: req.ip ?? null,
+      });
+      res.status(502).json({ ok: false, error: reason });
+    }
+  }),
+);
+
 // ---------- Retention sweep (on-demand) ----------
 
 adminRouter.post(

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -683,6 +683,20 @@ export const api = {
       };
     }>(`/admin/providers/${encodeURIComponent(key)}`, { method: 'DELETE' }),
 
+  // Provider test send — fires a real test message via the named
+  // provider (independent of the currently-active firm_settings choice)
+  // so an admin can verify credentials before flipping the switch.
+  testEmailProvider: (provider: 'postmark' | 'postfix' | 'emailit' | 'mock', to: string) =>
+    json<{ ok: true; providerMessageId: string; status: string }>('/admin/providers/test/email', {
+      method: 'POST',
+      body: JSON.stringify({ provider, to }),
+    }),
+  testSmsProvider: (provider: 'twilio' | 'textlink' | 'mock', to: string) =>
+    json<{ ok: true; providerMessageId: string; status: string }>('/admin/providers/test/sms', {
+      method: 'POST',
+      body: JSON.stringify({ provider, to }),
+    }),
+
   reinviteClient: (id: string, via?: 'email' | 'sms') =>
     json<{ ok: true; invitePublicKey: string; inviteSent: boolean; sendError?: string }>(
       `/admin/clients/${id}/reinvite`,

--- a/apps/web/src/pages/Admin.tsx
+++ b/apps/web/src/pages/Admin.tsx
@@ -3328,9 +3328,14 @@ interface ProviderSecretMeta {
 // Registry display metadata — matches the server's PROVIDER_SECRET_KEYS list
 // but adds user-facing labels and input affordances. Kept hardcoded client-side
 // so we control copy + don't have to round-trip "what's this field for" strings.
+type ProviderTestKind =
+  | { channel: 'email'; provider: 'postmark' | 'postfix' | 'emailit' }
+  | { channel: 'sms'; provider: 'twilio' | 'textlink' };
+
 const PROVIDER_GROUPS: {
   title: string;
   blurb: string;
+  test: ProviderTestKind;
   keys: {
     key: string;
     label: string;
@@ -3342,6 +3347,7 @@ const PROVIDER_GROUPS: {
     title: 'Email — Postmark',
     blurb:
       'Used when EMAIL_PROVIDER=postmark. Transactional email for client invites + notifications.',
+    test: { channel: 'email', provider: 'postmark' },
     keys: [
       {
         key: 'email.postmark.server_token',
@@ -3358,6 +3364,7 @@ const PROVIDER_GROUPS: {
   {
     title: 'Email — SMTP (Postfix compatible)',
     blurb: 'Used when EMAIL_PROVIDER=postfix. Direct SMTP (self-hosted relay or third-party).',
+    test: { channel: 'email', provider: 'postfix' },
     keys: [
       { key: 'email.smtp.host', label: 'Host', placeholder: 'smtp.example.com', inputType: 'text' },
       { key: 'email.smtp.port', label: 'Port', placeholder: '587', inputType: 'text' },
@@ -3375,6 +3382,7 @@ const PROVIDER_GROUPS: {
     title: 'Email — Emailit',
     blurb:
       'Used when EMAIL_PROVIDER=emailit. Transactional v2 API (emailit.com). API key is the only required field; the base URL defaults to https://api.emailit.com/v2.',
+    test: { channel: 'email', provider: 'emailit' },
     keys: [
       { key: 'email.emailit.api_key', label: 'API key', placeholder: 'Emailit API key' },
       {
@@ -3395,6 +3403,7 @@ const PROVIDER_GROUPS: {
     title: 'SMS — Twilio',
     blurb:
       'Used when SMS_PROVIDER=twilio. Either MessagingServiceSid or From number is required — not both.',
+    test: { channel: 'sms', provider: 'twilio' },
     keys: [
       {
         key: 'sms.twilio.account_sid',
@@ -3420,6 +3429,7 @@ const PROVIDER_GROUPS: {
   {
     title: 'SMS — TextLink',
     blurb: 'Used when SMS_PROVIDER=textlink.',
+    test: { channel: 'sms', provider: 'textlink' },
     keys: [
       { key: 'sms.textlink.api_key', label: 'API key', placeholder: 'TextLink API key' },
       {
@@ -3507,6 +3517,7 @@ function AdminProviders(): JSX.Element {
                   />
                 );
               })}
+              <ProviderTestPanel test={group.test} />
             </div>
           </section>
         ))}
@@ -3624,6 +3635,102 @@ function ProviderSecretRow({
           </div>
         )}
       </div>
+    </div>
+  );
+}
+
+// Inline test-send panel that lives under each provider section in
+// Admin → Providers. Lets an admin verify credentials by firing a real
+// test message to a recipient they pick — independent of whichever
+// provider firm_settings currently selects, so a new provider can be
+// proven before flipping the switch on outbound mail/SMS.
+function ProviderTestPanel({ test }: { test: ProviderTestKind }): JSX.Element {
+  const [recipient, setRecipient] = useState('');
+  const [status, setStatus] = useState<
+    | { kind: 'idle' }
+    | { kind: 'sending' }
+    | { kind: 'sent'; messageId: string }
+    | { kind: 'error'; reason: string }
+  >({ kind: 'idle' });
+
+  async function send(): Promise<void> {
+    if (!recipient.trim()) return;
+    setStatus({ kind: 'sending' });
+    try {
+      const r =
+        test.channel === 'email'
+          ? await api.testEmailProvider(test.provider, recipient.trim())
+          : await api.testSmsProvider(test.provider, recipient.trim());
+      setStatus({ kind: 'sent', messageId: r.providerMessageId });
+    } catch (err) {
+      // The /admin/providers/test/* routes return either 400 (validation
+      // / missing secrets) or 502 (provider rejected the send). Either
+      // way, json() throws an Error with the body attached as `.body`.
+      type ServerErr = { error?: string; reason?: string; keys?: string[] };
+      const bodyText = (err as { body?: string } | null)?.body ?? '';
+      let parsed: ServerErr | null = null;
+      try {
+        parsed = JSON.parse(bodyText) as ServerErr;
+      } catch {
+        parsed = null;
+      }
+      let reason: string;
+      if (parsed?.error === 'provider_secrets_missing') {
+        reason = `Missing credentials: ${(parsed.keys ?? []).join(', ')}. Save them above first.`;
+      } else if (parsed?.error) {
+        reason = String(parsed.error);
+      } else {
+        reason = err instanceof Error ? err.message : String(err);
+      }
+      setStatus({ kind: 'error', reason: reason.slice(0, 300) });
+    }
+  }
+
+  const placeholder = test.channel === 'email' ? 'admin@yourfirm.com' : '+15551234567';
+  const label = test.channel === 'email' ? 'Send test email to' : 'Send test SMS to';
+
+  return (
+    <div className="px-4 py-3 bg-slate-50/60">
+      <div className="flex flex-wrap items-center gap-2">
+        <label className="text-xs text-slate-700 font-medium" htmlFor={`test-${test.provider}`}>
+          {label}
+        </label>
+        <input
+          id={`test-${test.provider}`}
+          type={test.channel === 'email' ? 'email' : 'tel'}
+          value={recipient}
+          onChange={(e) => setRecipient(e.target.value)}
+          placeholder={placeholder}
+          className="flex-1 min-w-[200px] rounded-md border border-slate-300 px-3 py-1.5 text-sm"
+          disabled={status.kind === 'sending'}
+        />
+        <button
+          type="button"
+          onClick={() => void send()}
+          disabled={status.kind === 'sending' || !recipient.trim()}
+          className="btn-secondary text-xs disabled:opacity-50"
+        >
+          {status.kind === 'sending' ? 'Sending…' : 'Test'}
+        </button>
+      </div>
+      {status.kind === 'sent' && (
+        <div
+          className="mt-2 text-xs rounded-md border border-emerald-200 bg-emerald-50 text-emerald-800 px-3 py-2"
+          role="status"
+        >
+          Sent — provider message id <code>{status.messageId.slice(0, 40)}</code>. Check your inbox
+          / phone within ~30 s. If it doesn&apos;t arrive, look at the provider&apos;s dashboard
+          (sandbox keys often return 200 but never deliver).
+        </div>
+      )}
+      {status.kind === 'error' && (
+        <div
+          className="mt-2 text-xs rounded-md border border-rose-200 bg-rose-50 text-rose-800 px-3 py-2"
+          role="alert"
+        >
+          Failed: {status.reason}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## What

Under each provider section in **Admin → Providers**, a new **Test** panel: type a recipient (email address or phone number), click Test, see the green-or-red result inline.

The send uses the **named provider**, not whichever one `firm_settings` currently picks. That means an admin can prove Emailit credentials work *before* flipping the global setting to Emailit — no more "I flipped it and outbound mail died, what do I roll back".

## Why now

Three reports we've already triaged in this session — "email failed" toast, "I'm not seeing Emailit hit", "Toast says sent but nothing arrives" — collapse into a 30-second diagnostic loop with this button.

## API

```
POST /admin/providers/test/email   { provider: 'postmark'|'postfix'|'emailit'|'mock', to: <email> }
POST /admin/providers/test/sms     { provider: 'twilio'|'textlink'|'mock',          to: <phone>  }
```

- requireAdmin, rate-limited at 10 / 10 min / admin
- Pre-flight: rejects with `{error:'provider_secrets_missing', keys:[...]}` if the named provider's secrets aren't stored
- Audit row `admin.provider_test_sent` with `{provider, status, messageId|reason}`
- Success: `{ok:true, providerMessageId, status}`
- Provider error: `502 {ok:false, error:'<reason>'}` — already-redacted (Postmark token / Twilio SID / Emailit bearer)

## UI

```
┌─ Email — Emailit ──────────────────────────────────────────────┐
│ Used when EMAIL_PROVIDER=emailit. Transactional v2 API…       │
│                                                                │
│ API key:              [••••••••MAOl]              Edit  Clear  │
│ Base URL (optional):  [https://api.emailit.com/v2] Edit  Clear │
│ Reply-To (optional):  []                          Edit  Clear  │
│ ─────────────────────────────────────────────────────────────  │
│ Send test email to: [admin@yourfirm.com         ]    [ Test ] │
│ ✓ Sent — provider message id em_abc123def. Check your inbox.  │
└────────────────────────────────────────────────────────────────┘
```

(Similar panel under SMTP, Postmark, Twilio, TextLink.)

## Bridge refactor

`buildEmailProvider(kind)` + `buildSmsProvider(kind)` exports — same logic the resolver runs in `getEmailProvider()`, just exposed for the test routes. `currentEmailProviderKind()` exported alongside; not consumed yet but cheap and useful for future UI ("Emailit (active)" badge).

## Tests

- 5 new cases in `provider-selection.test.ts`:
  - email test rejects with `provider_secrets_missing` when emailit api_key is absent
  - sms test same shape for textlink
  - mock provider always succeeds + writes the audit row
  - validation rejects bad email format + unknown provider enum
  - non-admin (staff) gets 403
- Full suite: **249 server tests + 21 web tests** passing.

## Test plan

- [x] typecheck + lint + format clean
- [x] All test suites pass
- [ ] After v0.4.16 redeploy:
  - [ ] Test Emailit with admin's real email — confirm the test email arrives within ~30s
  - [ ] Test SMTP with intentionally wrong port — confirm error text is informative
  - [ ] Test TextLink — confirm the test SMS arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)