### PR TITLE
fix(intake): hide form-bounce ghost sessions from staff list + Inbox

### DIFF
--- a/apps/server/src/__tests__/intake-admin.test.ts
+++ b/apps/server/src/__tests__/intake-admin.test.ts
@@ -51,7 +51,7 @@ async function loginAs(username: string, password: string): Promise<TestAgent> {
 
 async function createSessionFor(
   staffId: string,
-  opts: { name?: string; email?: string; phone?: string } = {},
+  opts: { name?: string; email?: string; phone?: string; withFile?: boolean } = {},
 ): Promise<string> {
   const r = await request(app)
     .post('/api/public/intake/sessions')
@@ -62,7 +62,26 @@ async function createSessionFor(
       phone: opts.phone ?? '+15551234567',
     });
   expect(r.status).toBe(201);
-  return r.body.sessionId as string;
+  const sessionId = r.body.sessionId as string;
+  // v0.4.19 server-side filter hides `status='open' AND file_count=0`
+  // ghost sessions from the staff list + Inbox feed by default. Most
+  // tests want a "real" session (one with a file), so default to
+  // inserting a dummy intake_files row. Pass withFile:false to assert
+  // the abandoned/empty path.
+  if (opts.withFile !== false) {
+    const { db } = await import('../db/knex.js');
+    await db('intake_files').insert({
+      session_id: sessionId,
+      original_filename: 'test.bin',
+      stored_path: `/tmp/test-${sessionId}.bin`,
+      mime_type: 'application/octet-stream',
+      size_bytes: 1,
+      sha256: 'a'.repeat(64),
+      kind: 'file',
+      virus_scan_status: 'clean',
+    });
+  }
+  return sessionId;
 }
 
 describe('Phase 28.11 — GET /admin/intake/sessions list + RBAC', () => {
@@ -96,6 +115,25 @@ describe('Phase 28.11 — GET /admin/intake/sessions list + RBAC', () => {
     expect(r.status).toBe(200);
     const ids = r.body.sessions.map((s: { id: string }) => s.id);
     expect(ids).toEqual([bobSess]);
+  });
+
+  it('abandoned-empty sessions (open + 0 files) hide by default; includeAbandoned brings them back', async () => {
+    // Reproduces the report from v0.4.18: POST /sessions creates a row
+    // the moment a client clicks Next, so a form-bounce leaves a ghost
+    // open/0-file session. Staff want the list to show real submissions.
+    const ghostSess = await createSessionFor(aliceStaffId, { withFile: false });
+    const realSess = await createSessionFor(aliceStaffId); // withFile defaults to true
+    const aliceAgent = await loginAs('alice', 'alice-dev-only-ChangeMe!');
+
+    const def = await aliceAgent.get('/admin/intake/sessions');
+    const defIds = def.body.sessions.map((s: { id: string }) => s.id);
+    expect(defIds).toContain(realSess);
+    expect(defIds).not.toContain(ghostSess);
+
+    const all = await aliceAgent.get('/admin/intake/sessions?includeAbandoned=true');
+    const allIds = all.body.sessions.map((s: { id: string }) => s.id);
+    expect(allIds).toContain(realSess);
+    expect(allIds).toContain(ghostSess);
   });
 
   it('archived sessions are hidden by default and visible with includeArchived', async () => {

--- a/apps/server/src/routes/intakeAdmin.ts
+++ b/apps/server/src/routes/intakeAdmin.ts
@@ -71,6 +71,13 @@ const listQuerySchema = z.object({
   fromDate: z.string().optional(), // ISO date or datetime
   toDate: z.string().optional(),
   includeArchived: z.coerce.boolean().optional().default(false),
+  // POST /api/public/intake/sessions creates a session row the moment a
+  // client fills name/email and clicks Next, BEFORE any tus upload.
+  // Visitors who bounce after that produce `status='open' AND
+  // file_count=0` ghost rows that pollute the staff list. Default-hide
+  // them — staff want to see actual submissions. `includeAbandoned=true`
+  // brings them back for admins triaging "why are clients not finishing".
+  includeAbandoned: z.coerce.boolean().optional().default(false),
   sort: z
     .enum(['received_at_desc', 'received_at_asc', 'size_desc', 'size_asc'])
     .optional()
@@ -155,6 +162,14 @@ intakeAdminRouter.get(
     if (q.fromDate) query = query.where('s.created_at', '>=', q.fromDate);
     if (q.toDate) query = query.where('s.created_at', '<=', q.toDate);
     if (!q.includeArchived) query = query.whereNull('a.archived_at');
+    // Filter out form-bounce ghost rows (open + 0 files). Skipped when
+    // the caller explicitly asks for them OR when filtering by a
+    // non-'open' status (in which case file_count=0 is meaningful —
+    // e.g. an 'expired' session that ran out the clock with nothing
+    // uploaded is a real signal an admin might want to review).
+    if (!q.includeAbandoned && (!q.status || q.status === 'open')) {
+      query = query.whereRaw(`NOT (s.status = 'open' AND COALESCE(f."file_count", 0) = 0)`);
+    }
 
     // Sort
     switch (q.sort) {
@@ -652,6 +667,10 @@ intakeAdminRouter.get(
       .leftJoin('users as u', 'u.id', 's.staff_id')
       .whereNull('a.archived_at')
       .whereNull('a.read_at')
+      // Mirror the list-endpoint filter: form-bounce rows (open + 0
+      // files) shouldn't surface on the Inbox either — they're not
+      // actionable for staff.
+      .whereRaw(`NOT (s.status = 'open' AND COALESCE(f."file_count", 0) = 0)`)
       .modify((q) => {
         if (!isAdmin) q.where('s.staff_id', me);
       })

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -153,6 +153,7 @@ export const api = {
     status?: 'open' | 'finalized' | 'expired' | 'abandoned';
     staffId?: string;
     includeArchived?: boolean;
+    includeAbandoned?: boolean;
     sort?: 'received_at_desc' | 'received_at_asc' | 'size_desc' | 'size_asc';
   }) => {
     const q = new URLSearchParams();

--- a/apps/web/src/pages/Admin.tsx
+++ b/apps/web/src/pages/Admin.tsx
@@ -4668,6 +4668,11 @@ export function AdminIntakeSessions(): JSX.Element {
   const qc = useQueryClient();
   const [status, setStatus] = useState<'' | 'open' | 'finalized' | 'expired' | 'abandoned'>('');
   const [includeArchived, setIncludeArchived] = useState(false);
+  // Form-bounce rows (status=open AND 0 files) hide by default — the
+  // POST /sessions endpoint creates a row before any upload, so an
+  // abandoned form leaves a ghost session. Admins triaging drop-off
+  // can flip this on to see them.
+  const [includeAbandoned, setIncludeAbandoned] = useState(false);
   const [staffFilter, setStaffFilter] = useState<string>('');
   const [page, setPage] = useState(1);
   const [openDetailId, setOpenDetailId] = useState<string | null>(null);
@@ -4683,10 +4688,15 @@ export function AdminIntakeSessions(): JSX.Element {
   useEffect(() => {
     // Reset selection on any filter / page change.
     setSelected(new Set());
-  }, [status, includeArchived, staffFilter, page]);
+  }, [status, includeArchived, includeAbandoned, staffFilter, page]);
 
   const listQ = useQuery({
-    queryKey: ['admin', 'intake', 'sessions', { status, includeArchived, staffFilter, page }],
+    queryKey: [
+      'admin',
+      'intake',
+      'sessions',
+      { status, includeArchived, includeAbandoned, staffFilter, page },
+    ],
     queryFn: () =>
       api.listAdminIntakeSessions({
         page,
@@ -4694,6 +4704,7 @@ export function AdminIntakeSessions(): JSX.Element {
         status: status || undefined,
         staffId: staffFilter || undefined,
         includeArchived,
+        includeAbandoned,
       }),
     staleTime: 15_000,
   });
@@ -4783,6 +4794,17 @@ export function AdminIntakeSessions(): JSX.Element {
             onChange={(e) => setIncludeArchived(e.target.checked)}
           />
           Include archived
+        </label>
+        <label
+          className="text-xs text-slate-600 inline-flex items-center gap-1"
+          title="Sessions where the client filled the intake form but never uploaded a file. Hidden by default to keep the list focused on real submissions."
+        >
+          <input
+            type="checkbox"
+            checked={includeAbandoned}
+            onChange={(e) => setIncludeAbandoned(e.target.checked)}
+          />
+          Show form-bounce sessions
         </label>
       </div>
 


### PR DESCRIPTION
## What

Reported on a fresh appliance: the staff **Intake** tab was showing nine open / 0-file rows interspersed with one real finalised submission. Every visitor who hit the intake page and clicked Next on the contact form was creating a row, regardless of whether they ever uploaded anything.

## Root cause

`POST /api/public/intake/sessions` creates the `intake_sessions` row immediately so the server can mint an upload token (the client SPA needs the token before it can call tus). If the client bounces after that, the session stays at `status='open' AND file_count=0` forever, polluting every staff view.

## Fix

### Server (`routes/intakeAdmin.ts`)

- `GET /admin/intake/sessions` now defaults to `NOT (status='open' AND file_count=0)`. A new `includeAbandoned=true` query param brings the ghost rows back for admins triaging drop-off ("why aren't clients finishing the form?").
- The filter is **skipped** when the caller passes an explicit non-`open` status — `status=expired&file_count=0` is a real signal worth keeping ("client ran out the clock").
- `GET /admin/intake/inbox/intakes` hardcodes the same filter (no override) — the Inbox tile is meant for actionable items only.

### Web

- New checkbox "**Show form-bounce sessions**" next to "Include archived" on the Intake admin page. Tooltip explains what they are.
- `listAdminIntakeSessions` API signature gains `includeAbandoned`.

## Tests

- Added intake-admin case: `withFile:false` session is hidden by default and visible with `?includeAbandoned=true`.
- The `createSessionFor` helper now defaults to inserting a fake `intake_files` row so existing RBAC / archive tests still see their sessions. Pass `withFile:false` to assert the abandoned path.
- Full suite: **25 intake-admin tests passing** (24 prior + 1 new).

## Test plan

- [x] typecheck + lint + format clean
- [x] All test suites pass
- [ ] After v0.4.19 redeploy: confirm the staff Intake list shows only the one real submission, not the nine ghost rows; flip "Show form-bounce sessions" to see them all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)