### PR TITLE
fix(admin): SMTP pre-flight requires only host, not port

### DIFF
--- a/apps/server/src/__tests__/provider-selection.test.ts
+++ b/apps/server/src/__tests__/provider-selection.test.ts
@@ -197,6 +197,26 @@ describe('DB-backed provider selection', () => {
         .send({ provider: 'mock', to: 'admin@example.com' });
       expect(res.status).toBe(403);
     });
+
+    it('SMTP pre-flight requires only host — port has an env default (regression for v0.4.21)', async () => {
+      // User reported on v0.4.20: configuring SMTP host + password, then
+      // clicking Test, surfaced "Missing credentials: email.smtp.port".
+      // Port has an env default (587) so it's not actually required for
+      // the bridge to function. Only HOST is required up-front.
+      const { db } = await import('../db/knex.js');
+      const { set: setProviderSecret } = await import('../services/providerSecrets.js');
+      await db('firm_provider_credentials').delete();
+      await setProviderSecret('email.smtp.host', 'smtp.example.com', null);
+      // intentionally NO email.smtp.port stored.
+      const admin = await loginAs('kurt', 'kurt-dev-only-ChangeMe!');
+      const res = await admin
+        .post('/admin/providers/test/email')
+        .send({ provider: 'postfix', to: 'admin@example.com' });
+      // The send will still fail at the actual SMTP-connect step
+      // (smtp.example.com doesn't exist), but it should NOT fail with
+      // `provider_secrets_missing` for port.
+      expect(res.body.error).not.toBe('provider_secrets_missing');
+    });
   });
 });
 

--- a/apps/server/src/routes/admin.ts
+++ b/apps/server/src/routes/admin.ts
@@ -279,7 +279,13 @@ function normalizeAdminUrl(
 // discover every outbound notification failing at send time.
 const REQUIRED_SECRETS_BY_PROVIDER: Record<string, ProviderSecretKey[]> = {
   postmark: ['email.postmark.server_token'],
-  postfix: ['email.smtp.host', 'email.smtp.port'],
+  // SMTP: only HOST is truly required. PORT has an env default (587),
+  // user / pass are optional (some relays accept unauthenticated), and
+  // the `secure` flag defaults to STARTTLS. The pre-flight check is
+  // meant to catch "obviously broken" configs that would 100% fail at
+  // send time — partial / nuanced misconfigs (e.g. user without pass)
+  // are caught with friendlier errors at the actual send call.
+  postfix: ['email.smtp.host'],
   emailit: ['email.emailit.api_key'],
   textlink: ['sms.textlink.api_key'],
   twilio: ['sms.twilio.account_sid', 'sms.twilio.auth_token'],


### PR DESCRIPTION
## What

User report: configured SMTP host + password, clicked Test, got:

```
Failed: Missing credentials: email.smtp.port. Save them above first.
```

But port has an env default of **587**, so it's not actually required for the bridge to function. The pre-flight check was gating the test send on a knob that doesn't need to be set.

## Fix

Drop `email.smtp.port` from `REQUIRED_SECRETS_BY_PROVIDER.postfix`. Only `email.smtp.host` is truly required up-front. Partial / nuanced misconfigs (user without pass, wrong port for the secure flag, etc.) surface at send time with friendlier errors from the actual SMTP connect attempt.

The same `REQUIRED_SECRETS_BY_PROVIDER` map is used by:
- `POST /admin/providers/test/email` (the Test button)
- `PATCH /admin/settings` (flipping `emailProvider` to `postfix`)

Both paths now accept a postfix config with only host stored.

## Test

New regression case in `provider-selection.test.ts`:

```js
it('SMTP pre-flight requires only host — port has an env default (regression for v0.4.21)', async () => {
  await setProviderSecret('email.smtp.host', 'smtp.example.com', null);
  // intentionally NO email.smtp.port stored.
  const res = await admin.post('/admin/providers/test/email').send({ provider: 'postfix', to: '...' });
  expect(res.body.error).not.toBe('provider_secrets_missing');
});
```

Full provider-selection suite: 13 cases passing.

## Test plan

- [x] typecheck + lint + format clean
- [x] All test suites pass
- [ ] After v0.4.21 redeploy: in Admin → Providers → SMTP, save just host + password, click Test → expected outcome is either real SMTP success or a real SMTP error from the connect attempt, NOT `provider_secrets_missing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)