### PR TITLE
fix(textlink): correct API contract — silent-failure send was the bug

### DIFF
--- a/apps/server/src/__tests__/sms-providers.test.ts
+++ b/apps/server/src/__tests__/sms-providers.test.ts
@@ -35,6 +35,69 @@ describe('TextLink SMS', () => {
     await set('sms.textlink.api_key', 'test-tl-key', null);
   });
 
+  it('posts to /api/send-sms with Bearer auth + spec-shaped body (phone_number + text)', async () => {
+    // Regression for the silent-failure bug in v0.4.21 and earlier: api
+    // key was in the JSON body instead of the Authorization header, and
+    // the body used `to`/`message` instead of `phone_number`/`text` as
+    // the spec requires. https://docs.textlinksms.com/api#sending-an-sms
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    const { getSmsProvider } = await import('../bridges/sms/index.js');
+    const provider = await getSmsProvider();
+    const result = await provider.sendMessage({ to: '+15551234567', body: 'hi there' });
+    expect(result.status).toBe('sent');
+
+    const [urlArg, initArg] = fetchSpy.mock.calls[0]!;
+    expect(String(urlArg)).toBe('https://textlinksms.com/api/send-sms');
+    const init = initArg as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers.authorization).toBe('Bearer test-tl-key');
+    expect(headers['content-type']).toBe('application/json');
+    const sent = JSON.parse(String(init.body)) as Record<string, unknown>;
+    expect(sent.phone_number).toBe('+15551234567');
+    expect(sent.text).toBe('hi there');
+    // api_key MUST NOT appear in the body (it goes in the header).
+    expect('apiKey' in sent).toBe(false);
+    expect('api_key' in sent).toBe(false);
+  });
+
+  it('treats `queued: true` as success but reports status="queued"', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ ok: true, queued: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    const { getSmsProvider } = await import('../bridges/sms/index.js');
+    const provider = await getSmsProvider();
+    const result = await provider.sendMessage({ to: '+15551234567', body: 'hi' });
+    expect(result.status).toBe('queued');
+  });
+
+  it('THROWS when response is HTTP 200 with `ok: false` (silent-failure regression)', async () => {
+    // The user-reported bug: TextLink returns 200 OK with { ok: false,
+    // message: "..." } on a failed send (no SIM available, phone offline,
+    // etc.). Pre-v0.4.22 we checked HTTP status only, so every failure
+    // was reported as "sent" to the staff invite toast — no SMS went out
+    // but the UI claimed it had. The fix must parse `ok` and throw with
+    // the `message` text.
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ ok: false, message: 'No SIM cards available' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    const { getSmsProvider } = await import('../bridges/sms/index.js');
+    const provider = await getSmsProvider();
+    await expect(provider.sendMessage({ to: '+15551234567', body: 'hi' })).rejects.toThrow(
+      /textlink_send_failed: No SIM cards available/,
+    );
+  });
+
   it('maps timeout to textlink_timeout_after_*ms', async () => {
     vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
       Promise.reject(new DOMException('aborted', 'TimeoutError')),
@@ -46,7 +109,10 @@ describe('TextLink SMS', () => {
     );
   });
 
-  it('redacts long dash-free tokens but preserves UUIDs in 4xx body', async () => {
+  it('surfaces a real HTTP error (non-200) with redacted body', async () => {
+    // Non-200 from TextLink means the API itself is broken (deploy /
+    // outage / rate limit), not a "send failed". Distinct error string
+    // so an operator can tell them apart.
     const body =
       '{"err":"bad","key":"abcdefghijklmnopqrstuvwxyz1234567890","traceId":"12345678-1234-1234-1234-123456789012"}';
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(

--- a/apps/server/src/bridges/sms/index.ts
+++ b/apps/server/src/bridges/sms/index.ts
@@ -91,6 +91,21 @@ class MockSms implements SmsProvider {
   }
 }
 
+// TextLinkSMS — BYOD Android-phone-as-SMS-gateway service.
+//   Endpoint:        POST https://textlinksms.com/api/send-sms
+//   Auth:            Authorization: Bearer <api_key>  (NOT in body)
+//   Body (JSON):     { phone_number: "+1...", text: "..." }
+//                    Optional: sim_card_id, custom_id
+//   Response:        HTTP 200 always. Success: { ok: true [, queued: true] }
+//                    Failure: { ok: false, message: "<reason>" }
+//   Spec reference:  https://docs.textlinksms.com/api#sending-an-sms
+//
+// This is the silent-failure path the user hit: prior versions of this
+// code put the api key in the request body, used the wrong field names
+// (`to`/`message` instead of `phone_number`/`text`), AND treated any
+// HTTP 200 as success — so a body of `{ok: false, message: "..."}` was
+// being reported as "sent" to the staff invite toast while no SMS ever
+// went out. Each of those three is fixed here.
 class TextLinkSms implements SmsProvider {
   name = 'textlink' as const;
   async sendMessage(req: SmsSendRequest) {
@@ -100,20 +115,47 @@ class TextLinkSms implements SmsProvider {
     try {
       res = await fetch('https://textlinksms.com/api/send-sms', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ apiKey, to: req.to, message: req.body }),
+        headers: {
+          authorization: `Bearer ${apiKey}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ phone_number: req.to, text: req.body }),
         signal: AbortSignal.timeout(SMS_PROVIDER_TIMEOUT_MS),
       });
     } catch (err) {
       throw mapSmsFetchError('textlink', err);
     }
+    // TextLink uses HTTP 200 even for failures and signals success via
+    // the `ok` field. A non-200 here means the API itself is broken
+    // (rate-limit, deploy, etc.) — read the body for diagnostics.
     if (!res.ok) {
       const full = await res.text();
-      logger.warn('sms.textlink_send_failed', { status: res.status, body: full.slice(0, 500) });
+      logger.warn('sms.textlink_http_error', { status: res.status, body: full.slice(0, 500) });
       throw new Error(`textlink_${res.status}: ${redactAndCapSms(full)}`);
     }
-    const data = (await res.json()) as { messageId?: string };
-    return { id: data.messageId ?? crypto.randomUUID(), status: 'sent' as const };
+    interface TextLinkResponse {
+      ok?: boolean;
+      queued?: boolean;
+      message?: string;
+    }
+    let parsed: TextLinkResponse | null = null;
+    try {
+      parsed = (await res.json()) as TextLinkResponse;
+    } catch {
+      parsed = null;
+    }
+    if (!parsed || parsed.ok !== true) {
+      const reason = parsed?.message ?? '<no reason given>';
+      logger.warn('sms.textlink_send_failed', { reason, body: parsed });
+      throw new Error(`textlink_send_failed: ${reason.slice(0, 200)}`);
+    }
+    // Spec returns no message id — synthesise one for our log + audit.
+    // `queued` is a second-state-of-success (handed to a SIM card but
+    // not yet acked) — both count as a successful send from our pov.
+    return {
+      id: `textlink-${Date.now()}-${crypto.randomBytes(4).toString('hex')}`,
+      status: parsed.queued ? ('queued' as const) : ('sent' as const),
+    };
   }
   parseInbound(req: { body: unknown }): SmsInbound | null {
     const b = req.body as {


### PR DESCRIPTION
## Why

User report: *"the textlinksms is not sending messages. review https://docs.textlinksms.com/api#sending-an-sms and ensure the code has no errors and functions properly"*

Diagnosis against the live spec revealed **three wire-shape errors plus one silent-failure bug**. Any of the first three was enough to make every send fail — but the silent-failure bug masked those failures as successes upstream, so the staff invite toast was reporting "SMS sent" while no SMS ever went out.

## Bugs found

| # | Spec | What we had | Impact |
|---|---|---|---|
| 1 | `Authorization: Bearer <key>` header | `body: { apiKey, ... }` | TextLink rejects (no auth) |
| 2 | `body.phone_number` | `body.to` | TextLink rejects (missing field) |
| 3 | `body.text` | `body.message` | TextLink rejects (missing field) |
| 4 | HTTP 200 + `{ ok: false, message }` on failure | Treated any 200 as success | **Silent failure** — UI lied |

## Fix

```js
fetch('https://textlinksms.com/api/send-sms', {
  method: 'POST',
  headers: {
    authorization: `Bearer ${apiKey}`,
    'content-type': 'application/json',
  },
  body: JSON.stringify({ phone_number: req.to, text: req.body }),
});

// THEN: parse the body and check ok === true
if (!parsed || parsed.ok !== true) {
  throw new Error(`textlink_send_failed: ${parsed?.message ?? '<no reason>'}`);
}
```

New distinct error namespace:
- `textlink_<status>` — non-200 HTTP (rate-limit, outage, deploy)
- `textlink_send_failed: <reason>` — HTTP 200 but `ok: false`

`{ ok: true, queued: true }` is also accepted as success but reports `status: 'queued'` so the audit row distinguishes "handed to phone" from "phone ack'd send".

## Tests

New cases in `sms-providers.test.ts`:

```ts
it('posts to /api/send-sms with Bearer auth + spec-shaped body', ...)
// asserts Authorization: Bearer header, phone_number + text fields,
// and that apiKey/api_key are NOT in the body.

it('treats `queued: true` as success but reports status="queued"', ...)

it('THROWS when response is HTTP 200 with `ok: false` (silent-failure regression)', ...)
// mocks { ok: false, message: "No SIM cards available" } → expects throw
```

Full SMS suite: **8 cases, all passing**.

## Test plan

- [x] typecheck + lint + format clean
- [x] All test suites pass
- [ ] After v0.4.22 redeploy:
  - [ ] In Admin → Providers → SMS → TextLink, click **Test** with your real phone number
  - [ ] Expected outcomes:
    - Success → SMS arrives within ~10s
    - Failure → toast shows the actual TextLink reason (e.g. *"No SIM cards available"*, *"Phone offline"*) so you can fix it on the phone side

🤖 Generated with [Claude Code](https://claude.com/claude-code)