### PR TITLE
fix(web): raw-fetch + sw paths honour BASE_PATH; Account / Prefs pages scroll

### DIFF
--- a/apps/web/src/pages/Account.tsx
+++ b/apps/web/src/pages/Account.tsx
@@ -28,24 +28,32 @@ function relativeTime(iso: string): string {
 export function AccountPage(): JSX.Element {
   const { user, refresh } = useAuth();
   const qc = useQueryClient();
+  // AppShell allocates a flex column with a fixed-height main area.
+  // The previous wrapper was a plain padded div, which let the
+  // password / device / intake-card sections overflow the viewport
+  // without scrolling (the user couldn't reach the Save buttons at
+  // the bottom). Match Inbox.tsx's pattern: `h-full overflow-y-auto`
+  // on the outer wrapper, padding moved to an inner content div.
   return (
-    <div className="p-4 max-w-2xl space-y-6">
-      <div>
-        <h2 className="font-semibold text-slate-900">Account</h2>
-        <p className="text-sm text-slate-600">
-          Signed in as <strong>{user?.displayName}</strong>{' '}
-          <span className="text-slate-400">(@{user?.username})</span>
-        </p>
+    <div className="h-full overflow-y-auto">
+      <div className="p-4 max-w-2xl space-y-6 pb-8">
+        <div>
+          <h2 className="font-semibold text-slate-900">Account</h2>
+          <p className="text-sm text-slate-600">
+            Signed in as <strong>{user?.displayName}</strong>{' '}
+            <span className="text-slate-400">(@{user?.username})</span>
+          </p>
+        </div>
+        <AvatarCard
+          onUploaded={() => {
+            void refresh();
+            void qc.invalidateQueries({ queryKey: ['users'] });
+          }}
+        />
+        <IntakeCardSettings />
+        <ChangePasswordCard />
+        <MyDevicesCard />
       </div>
-      <AvatarCard
-        onUploaded={() => {
-          void refresh();
-          void qc.invalidateQueries({ queryKey: ['users'] });
-        }}
-      />
-      <IntakeCardSettings />
-      <ChangePasswordCard />
-      <MyDevicesCard />
     </div>
   );
 }

--- a/apps/web/src/pages/NotificationPrefs.tsx
+++ b/apps/web/src/pages/NotificationPrefs.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { api } from '../api.js';
 import { useAuth } from '../state/auth.js';
+import { url as appUrl } from '../lib/boot.js';
 import { enablePush, useDesktopNotifications } from '../state/notifications.js';
 
 interface Prefs {
@@ -17,8 +18,15 @@ interface Prefs {
   sms_fallback_urgent_only: number;
 }
 
-async function json<T>(url: string, init?: RequestInit): Promise<T> {
-  const r = await fetch(url, {
+// MUST route through `appUrl()` so the BASE_PATH prefix is applied. On
+// the multi-app appliance the staff app lives at /connect/ and the
+// upstream Caddy strip_prefix only fires for /connect/*; a raw fetch
+// to `/notifications/prefs` falls into the apex catch-all → console
+// 404. The other staff fetches use api.ts's helper which already
+// applies appUrl; this page predates that and was its own fetch
+// wrapper, so we add the prefix here.
+async function json<T>(path: string, init?: RequestInit): Promise<T> {
+  const r = await fetch(appUrl(path), {
     ...init,
     credentials: 'include',
     headers: { 'Content-Type': 'application/json', ...(init?.headers ?? {}) },
@@ -46,7 +54,12 @@ export function NotificationPrefsPage(): JSX.Element {
     onSuccess: () => qc.invalidateQueries({ queryKey: ['notification-prefs'] }),
   });
 
-  if (!q.data) return <div className="p-6 text-sm text-slate-500">Loading…</div>;
+  if (!q.data)
+    return (
+      <div className="h-full overflow-y-auto">
+        <div className="p-6 text-sm text-slate-500">Loading…</div>
+      </div>
+    );
   const p = q.data;
   const smsAvailableAtFirm = policyQ.data?.smsAvailable !== false; // default to true while loading
   const hasPhone = Boolean(user?.phone);
@@ -56,145 +69,147 @@ export function NotificationPrefsPage(): JSX.Element {
   // doesn't strand the toggle), but block enabling.
   const canEnableSms = smsAvailableAtFirm && hasPhone;
   return (
-    <div className="max-w-lg p-6 space-y-4">
-      <h2 className="font-semibold text-slate-900 text-lg">Notifications</h2>
+    <div className="h-full overflow-y-auto">
+      <div className="max-w-lg p-6 space-y-4 pb-8">
+        <h2 className="font-semibold text-slate-900 text-lg">Notifications</h2>
 
-      <div className="bg-white rounded shadow-card p-4 space-y-2">
-        <h3 className="font-medium text-slate-800">Desktop</h3>
-        <p className="text-sm text-slate-600">
-          Current browser permission: <strong>{permission}</strong>
-        </p>
-        {permission !== 'granted' && (
+        <div className="bg-white rounded shadow-card p-4 space-y-2">
+          <h3 className="font-medium text-slate-800">Desktop</h3>
+          <p className="text-sm text-slate-600">
+            Current browser permission: <strong>{permission}</strong>
+          </p>
+          {permission !== 'granted' && (
+            <button
+              type="button"
+              className="rounded-md bg-brand-600 text-white text-sm px-3 py-1.5 hover:bg-brand-700"
+              onClick={() => void requestPermission()}
+            >
+              Enable
+            </button>
+          )}
+        </div>
+
+        <div className="bg-white rounded shadow-card p-4 space-y-2">
+          <h3 className="font-medium text-slate-800">Mobile / Push</h3>
+          <p className="text-sm text-slate-600">
+            Push notifications never include message content — only a &quot;you have a new
+            message&quot; prompt.
+          </p>
           <button
             type="button"
             className="rounded-md bg-brand-600 text-white text-sm px-3 py-1.5 hover:bg-brand-700"
-            onClick={() => void requestPermission()}
+            onClick={() =>
+              enablePush().then((ok) => alert(ok ? 'Enabled' : 'Failed — check browser support'))
+            }
           >
-            Enable
+            Enable push
           </button>
-        )}
-      </div>
+        </div>
 
-      <div className="bg-white rounded shadow-card p-4 space-y-2">
-        <h3 className="font-medium text-slate-800">Mobile / Push</h3>
-        <p className="text-sm text-slate-600">
-          Push notifications never include message content — only a &quot;you have a new
-          message&quot; prompt.
-        </p>
-        <button
-          type="button"
-          className="rounded-md bg-brand-600 text-white text-sm px-3 py-1.5 hover:bg-brand-700"
-          onClick={() =>
-            enablePush().then((ok) => alert(ok ? 'Enabled' : 'Failed — check browser support'))
-          }
-        >
-          Enable push
-        </button>
-      </div>
-
-      <div className="bg-white rounded shadow-card p-4 space-y-3">
-        <h3 className="font-medium text-slate-800">Do Not Disturb</h3>
-        <label className="flex items-center gap-2 text-sm">
-          <input
-            type="checkbox"
-            defaultChecked={p.dnd_enabled}
-            onChange={(e) => mut.mutate({ dndEnabled: e.target.checked })}
-          />
-          Enable DND
-        </label>
-        <div className="flex gap-3 items-center text-sm">
-          <label>
-            Start:
+        <div className="bg-white rounded shadow-card p-4 space-y-3">
+          <h3 className="font-medium text-slate-800">Do Not Disturb</h3>
+          <label className="flex items-center gap-2 text-sm">
             <input
-              type="time"
-              defaultValue={p.dnd_start}
-              onBlur={(e) => mut.mutate({ dndStart: e.target.value })}
-              className="ml-2 rounded border border-slate-300 px-2 py-1"
+              type="checkbox"
+              defaultChecked={p.dnd_enabled}
+              onChange={(e) => mut.mutate({ dndEnabled: e.target.checked })}
             />
+            Enable DND
           </label>
-          <label>
-            End:
+          <div className="flex gap-3 items-center text-sm">
+            <label>
+              Start:
+              <input
+                type="time"
+                defaultValue={p.dnd_start}
+                onBlur={(e) => mut.mutate({ dndStart: e.target.value })}
+                className="ml-2 rounded border border-slate-300 px-2 py-1"
+              />
+            </label>
+            <label>
+              End:
+              <input
+                type="time"
+                defaultValue={p.dnd_end}
+                onBlur={(e) => mut.mutate({ dndEnd: e.target.value })}
+                className="ml-2 rounded border border-slate-300 px-2 py-1"
+              />
+            </label>
+          </div>
+          <label className="flex items-center gap-2 text-sm">
             <input
-              type="time"
-              defaultValue={p.dnd_end}
-              onBlur={(e) => mut.mutate({ dndEnd: e.target.value })}
-              className="ml-2 rounded border border-slate-300 px-2 py-1"
+              type="checkbox"
+              defaultChecked={p.urgent_overrides_dnd}
+              onChange={(e) => mut.mutate({ urgentOverridesDnd: e.target.checked })}
             />
+            Urgent messages still ring during DND
           </label>
         </div>
-        <label className="flex items-center gap-2 text-sm">
-          <input
-            type="checkbox"
-            defaultChecked={p.urgent_overrides_dnd}
-            onChange={(e) => mut.mutate({ urgentOverridesDnd: e.target.checked })}
-          />
-          Urgent messages still ring during DND
-        </label>
-      </div>
 
-      <div className="bg-white rounded shadow-card p-4 space-y-2">
-        <h3 className="font-medium text-slate-800">Email fallback</h3>
-        <label className="flex items-center gap-2 text-sm">
-          <input
-            type="checkbox"
-            defaultChecked={p.email_fallback_enabled}
-            onChange={(e) => mut.mutate({ emailFallbackEnabled: e.target.checked })}
-          />
-          Email me when I&apos;m offline
-        </label>
-        <label className="flex items-center gap-2 text-sm">
-          <input
-            type="checkbox"
-            defaultChecked={Boolean(p.email_fallback_urgent_only)}
-            onChange={(e) => mut.mutate({ emailFallbackUrgentOnly: e.target.checked })}
-          />
-          Only for urgent messages
-        </label>
-        <p className="text-xs text-slate-500">
-          Emails intentionally never include message content — just a &quot;you have a new
-          message&quot; link.
-          {!user?.email && (
-            <span className="block mt-1 text-amber-700">
-              No email on file — your admin sets this on your user account.
-            </span>
+        <div className="bg-white rounded shadow-card p-4 space-y-2">
+          <h3 className="font-medium text-slate-800">Email fallback</h3>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              defaultChecked={p.email_fallback_enabled}
+              onChange={(e) => mut.mutate({ emailFallbackEnabled: e.target.checked })}
+            />
+            Email me when I&apos;m offline
+          </label>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              defaultChecked={Boolean(p.email_fallback_urgent_only)}
+              onChange={(e) => mut.mutate({ emailFallbackUrgentOnly: e.target.checked })}
+            />
+            Only for urgent messages
+          </label>
+          <p className="text-xs text-slate-500">
+            Emails intentionally never include message content — just a &quot;you have a new
+            message&quot; link.
+            {!user?.email && (
+              <span className="block mt-1 text-amber-700">
+                No email on file — your admin sets this on your user account.
+              </span>
+            )}
+          </p>
+        </div>
+
+        <PhoneCard phone={user?.phone ?? null} onSaved={() => refresh()} />
+
+        <div className="bg-white rounded shadow-card p-4 space-y-2">
+          <h3 className="font-medium text-slate-800">SMS fallback</h3>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={p.sms_fallback_enabled}
+              disabled={!canEnableSms && !p.sms_fallback_enabled}
+              onChange={(e) => mut.mutate({ smsFallbackEnabled: e.target.checked })}
+            />
+            Text me when I&apos;m offline
+          </label>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              defaultChecked={Boolean(p.sms_fallback_urgent_only)}
+              disabled={!p.sms_fallback_enabled}
+              onChange={(e) => mut.mutate({ smsFallbackUrgentOnly: e.target.checked })}
+            />
+            Only for urgent messages
+          </label>
+          <p className="text-xs text-slate-500">Texts are metadata-only — same rule as email.</p>
+          {!hasPhone && (
+            <p className="text-xs text-amber-700">
+              Add a mobile number above before enabling SMS notifications.
+            </p>
           )}
-        </p>
-      </div>
-
-      <PhoneCard phone={user?.phone ?? null} onSaved={() => refresh()} />
-
-      <div className="bg-white rounded shadow-card p-4 space-y-2">
-        <h3 className="font-medium text-slate-800">SMS fallback</h3>
-        <label className="flex items-center gap-2 text-sm">
-          <input
-            type="checkbox"
-            checked={p.sms_fallback_enabled}
-            disabled={!canEnableSms && !p.sms_fallback_enabled}
-            onChange={(e) => mut.mutate({ smsFallbackEnabled: e.target.checked })}
-          />
-          Text me when I&apos;m offline
-        </label>
-        <label className="flex items-center gap-2 text-sm">
-          <input
-            type="checkbox"
-            defaultChecked={Boolean(p.sms_fallback_urgent_only)}
-            disabled={!p.sms_fallback_enabled}
-            onChange={(e) => mut.mutate({ smsFallbackUrgentOnly: e.target.checked })}
-          />
-          Only for urgent messages
-        </label>
-        <p className="text-xs text-slate-500">Texts are metadata-only — same rule as email.</p>
-        {!hasPhone && (
-          <p className="text-xs text-amber-700">
-            Add a mobile number above before enabling SMS notifications.
-          </p>
-        )}
-        {hasPhone && !smsAvailableAtFirm && (
-          <p className="text-xs text-amber-700">
-            Your firm&apos;s SMS provider isn&apos;t configured. Ask an admin to set one up in{' '}
-            <strong>Admin → Text messages</strong>.
-          </p>
-        )}
+          {hasPhone && !smsAvailableAtFirm && (
+            <p className="text-xs text-amber-700">
+              Your firm&apos;s SMS provider isn&apos;t configured. Ask an admin to set one up in{' '}
+              <strong>Admin → Text messages</strong>.
+            </p>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/state/pwa.ts
+++ b/apps/web/src/state/pwa.ts
@@ -1,5 +1,6 @@
 // Service worker registration + "Add to home screen" prompt tracker.
 import { useEffect, useState } from 'react';
+import { url } from '../lib/boot.js';
 
 interface BeforeInstallPromptEvent extends Event {
   prompt: () => Promise<void>;
@@ -8,8 +9,20 @@ interface BeforeInstallPromptEvent extends Event {
 
 export function registerServiceWorker(): void {
   if (!('serviceWorker' in navigator)) return;
+  // Both the script path AND the scope must honour BASE_PATH. On the
+  // multi-app appliance the staff bundle lives under /connect/, the
+  // upstream Caddy strips /connect before forwarding, so a raw `/sw.js`
+  // request lands at Caddy's apex catch-all (the console) → 404. The
+  // scope option pins the SW to the prefix too — without it Chrome
+  // would refuse to register a SW whose script path is more specific
+  // than the page's directory.
+  const swPath = url('/sw.js');
+  // `scope` must end with `/` and be no more specific than the script
+  // path. `${basePath}/` works in both modes — single-app: `/`; multi-
+  // app: `/connect/`.
+  const swScope = url('/');
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js').catch((err) => {
+    navigator.serviceWorker.register(swPath, { scope: swScope }).catch((err) => {
       // eslint-disable-next-line no-console
       console.warn('sw registration failed', err);
     });


### PR DESCRIPTION
## What

Three bugs reported on the multi-app appliance (staff at `vibe.cpa2web.app/connect/...`). Common root cause: Caddy's apex vhost uses `handle /connect/* { uri strip_prefix /connect }`, so any request without the `/connect` prefix lands at Caddy's catch-all (the console admin UI), which 404s.

### 1. `NotificationPrefs.tsx` 404

```
GET https://vibe.cpa2web.app/notifications/prefs 404
```

The page had its own raw `fetch(url, ...)` helper bypassing `api.ts`'s `url()` — so the BASE_PATH `/connect` prefix was never applied. The request went to Caddy's apex → console → 404. **Fix:** route through `appUrl()` from `lib/boot.js`.

### 2. Service worker 404

```
Failed to register a ServiceWorker for scope ('https://vibe.cpa2web.app/')
with script ('https://vibe.cpa2web.app/sw.js'): 404
```

`navigator.serviceWorker.register('/sw.js')` was hard-coded to root, same `/connect`-missing failure. **Fix:** register `url('/sw.js')` with explicit `scope: url('/')`. Both honour BASE_PATH so the script is fetched at `/connect/sw.js` (Caddy strips, nginx serves from `/usr/share/nginx/html/web/sw.js`).

### 3. `/connect/account` doesn't scroll

> *"The https://vibe.cpa2web.app/connect/account does not scroll to allow the user to see the entire screen view"*

AppShell allocates a fixed-height main container; pages need to wrap their content in `h-full overflow-y-auto` for content to scroll independently. `Inbox.tsx` does this; `Account.tsx` and `NotificationPrefs.tsx` didn't. **Fix:** mirror the Inbox wrapper pattern on both pages.

## Test plan

- [x] typecheck + lint + format clean
- [ ] After v0.4.24 redeploy:
  - [ ] `vibe.cpa2web.app/connect/notifications` loads prefs (no 404 in DevTools)
  - [ ] Service worker registers (no `sw registration failed` in console)
  - [ ] `/connect/account` scrolls to show every section including Devices
  - [ ] `/connect/notifications` scrolls to show the SMS fallback toggle at the bottom

## Out of scope (separate fix if it persists)

The WebSocket failure (`wss://vibe.cpa2web.app/connect/socket.io/...`) wasn't a path issue — the URL is correct under BASE_PATH and Caddy's `strip_prefix` should route it through. If it keeps failing after this deploy, we'll dig into Caddy WS-upgrade headers or session-cookie scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)