### PR TITLE
fix(portal): host-aware session cookie path

### DIFF
--- a/apps/server/src/__tests__/portal-cookie-path.test.ts
+++ b/apps/server/src/__tests__/portal-cookie-path.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Regression: the portal session cookie's `path=` must be derived from
+ * the request's Host (matched against firm_settings.portal_url /
+ * site_url), NOT pinned globally to env.sessionCookiePath.
+ *
+ * The user-reported symptom: on a multi-subdomain appliance the staff
+ * app lives at vibe.<domain>/connect/ (so SESSION_COOKIE_PATH=/connect)
+ * AND the portal lives at client.<domain>/ — the cookie inherited the
+ * /connect scope, the browser refused to send it back for /portal/*
+ * requests, every /portal/me 401'd, and clients couldn't log in even
+ * with a correct access code.
+ *
+ * This test seeds a code via the access-codes service, POSTs /verify
+ * with the host header set to client.<domain>, and asserts the
+ * Set-Cookie response carries Path=/ — independent of what
+ * env.sessionCookiePath was (the env value still applies to root-host
+ * fallbacks).
+ */
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import request from 'supertest';
+import type { Express } from 'express';
+import { resetTestDb } from './test-helpers.js';
+
+let app: Express;
+
+beforeAll(async () => {
+  process.env.NODE_ENV = 'test';
+  process.env.DATABASE_URL =
+    process.env.TEST_DATABASE_URL ?? 'postgres://vibe:vibe@localhost:5435/vibe_connect_test';
+  await resetTestDb();
+  const mod = await import('../app.js');
+  app = mod.createApp();
+}, 120_000);
+
+beforeEach(async () => {
+  const { db } = await import('../db/knex.js');
+  await db('client_sessions').del();
+  await db('access_codes').del();
+  await db('external_identities').del();
+});
+
+async function seedClientWithCode(): Promise<{
+  email: string;
+  code: string;
+  identityId: string;
+}> {
+  const { db } = await import('../db/knex.js');
+  const { issueAccessCode } = await import('../services/accessCodes.js');
+  const email = `verify-${Date.now()}@example.com`;
+  const [row] = await db('external_identities')
+    .insert({
+      email,
+      display_name: 'Verify Tester',
+      verification_type: 'none',
+      verification_required: false,
+    })
+    .returning([
+      'id',
+      'email',
+      'phone',
+      'display_name',
+      'verification_type',
+      'verification_last4_hash',
+      'verification_required',
+      'deactivated_at',
+    ]);
+  const { code } = await issueAccessCode(
+    {
+      id: row.id as string,
+      email: row.email as string,
+      phone: (row.phone as string | null) ?? null,
+      display_name: row.display_name as string,
+      verification_type: row.verification_type as 'ssn' | 'ein' | 'none',
+      verification_last4_hash: (row.verification_last4_hash as string | null) ?? null,
+      verification_required: row.verification_required as boolean,
+      deactivated_at: (row.deactivated_at as string | null) ?? null,
+    },
+    'email',
+  );
+  return { email, code, identityId: row.id as string };
+}
+
+function pathFromSetCookie(raw: string | string[] | undefined): string | null {
+  if (!raw) return null;
+  const headers = Array.isArray(raw) ? raw : [raw];
+  for (const h of headers) {
+    if (!/^vibe\.portal=/.test(h)) continue;
+    const m = /Path=([^;]+)/i.exec(h);
+    if (m) return m[1] ?? null;
+  }
+  return null;
+}
+
+describe('portal verify cookie path is host-derived', () => {
+  it('Host=client.<domain> with portalUrl pointing there → Path=/', async () => {
+    // The multi-subdomain case the user hit. Set portal_url so
+    // effectiveUrls() matches the request's Host and derives `/`.
+    const { db } = await import('../db/knex.js');
+    await db('firm_settings').where({ id: 1 }).update({
+      site_url: 'https://vibe.cpa2web.app/connect',
+      portal_url: 'https://client.cpa2web.app',
+    });
+    const { email, code } = await seedClientWithCode();
+    const res = await request(app)
+      .post('/portal/verify')
+      .set('Host', 'client.cpa2web.app')
+      .send({ identifier: email, code, sessionPublicKey: 'pk' });
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    const cookiePath = pathFromSetCookie(res.headers['set-cookie']);
+    expect(cookiePath).toBe('/');
+  });
+
+  it('Host=vibe.<domain> with siteUrl pointing to /connect → Path=/connect', async () => {
+    // The staff-host case. The same /verify endpoint can also fire on
+    // the staff subdomain (e.g. staff impersonating a portal session
+    // during dev) — the cookie should land at /connect there.
+    const { db } = await import('../db/knex.js');
+    await db('firm_settings').where({ id: 1 }).update({
+      site_url: 'https://vibe.cpa2web.app/connect',
+      portal_url: 'https://client.cpa2web.app',
+    });
+    const { email, code } = await seedClientWithCode();
+    const res = await request(app)
+      .post('/portal/verify')
+      .set('Host', 'vibe.cpa2web.app')
+      .send({ identifier: email, code, sessionPublicKey: 'pk' });
+    expect(res.status).toBe(200);
+    const cookiePath = pathFromSetCookie(res.headers['set-cookie']);
+    expect(cookiePath).toBe('/connect');
+  });
+
+  it('Host that matches neither portalUrl nor siteUrl falls back to env default', async () => {
+    // Localhost / dev-test request — fall back to env.sessionCookiePath
+    // (defaults to "/").
+    const { db } = await import('../db/knex.js');
+    await db('firm_settings').where({ id: 1 }).update({
+      site_url: 'https://vibe.cpa2web.app/connect',
+      portal_url: 'https://client.cpa2web.app',
+    });
+    const { email, code } = await seedClientWithCode();
+    const res = await request(app)
+      .post('/portal/verify')
+      .set('Host', 'localhost:4000')
+      .send({ identifier: email, code, sessionPublicKey: 'pk' });
+    expect(res.status).toBe(200);
+    const cookiePath = pathFromSetCookie(res.headers['set-cookie']);
+    // Env default is '/' in the test environment.
+    expect(cookiePath).toBe('/');
+  });
+});

--- a/apps/server/src/routes/portal.ts
+++ b/apps/server/src/routes/portal.ts
@@ -30,6 +30,46 @@ export const portalRouter = Router();
 
 const SESSION_COOKIE = 'vibe.portal';
 
+/**
+ * Per-request cookie path for the portal session cookie.
+ *
+ * Mirrors the host-aware basePath derivation in routes/bootstrap.ts:
+ * a multi-subdomain appliance puts the staff app at
+ * `vibe.<domain>/connect/` (so `SESSION_COOKIE_PATH=/connect`) AND the
+ * portal at `client.<domain>/` (which needs path `/`). With a single
+ * env-only `SESSION_COOKIE_PATH`, the portal would inherit `/connect`,
+ * the browser would refuse to send the cookie back for `/portal/*`
+ * requests, every /portal/me would 401, and the SPA would bounce the
+ * user back to the identify page — the user's verify-but-no-login
+ * report drops cleanly out of that chain.
+ *
+ * Resolution order:
+ *   1. Match the request's Host against the configured portalUrl /
+ *      siteUrl and use that URL's pathname (rstripped of `/`, falling
+ *      back to `/` if empty). This is the same algorithm bootstrap.ts
+ *      already runs for the SPA's basePath.
+ *   2. Fall back to the env default — preserves the prior shape for
+ *      single-app installs that don't override portalUrl/siteUrl.
+ */
+async function cookiePathForRequest(req: Request): Promise<string> {
+  const reqHost = req.get('host');
+  if (!reqHost) return env.sessionCookiePath;
+  const urls = await effectiveUrls();
+  for (const url of [urls.portalUrl, urls.siteUrl]) {
+    if (!url) continue;
+    try {
+      const parsed = new URL(url);
+      if (parsed.host === reqHost) {
+        const stripped = parsed.pathname.replace(/\/$/, '');
+        return stripped || '/';
+      }
+    } catch {
+      // Malformed URL — skip and try the next candidate.
+    }
+  }
+  return env.sessionCookiePath;
+}
+
 const identifyLimiter = rateLimit({
   windowMs: 10 * 60 * 1000,
   limit: env.rateLimitPortalCodePer10Min,
@@ -172,11 +212,12 @@ portalRouter.post(
 
     res.cookie(SESSION_COOKIE, token, {
       httpOnly: true,
-      // Distribution mode: scope to BASE_PATH so a sibling Vibe app on the
-      // same host can't read the portal cookie (single-app: '/'; multi-app:
-      // '/connect'). clearCookie below uses the same path so logout works
-      // regardless of mode.
-      path: env.sessionCookiePath,
+      // Per-request path derivation — see cookiePathForRequest. The
+      // multi-subdomain appliance puts portal on `client.<domain>/`
+      // (path needs to be `/`) and staff on `vibe.<domain>/connect/`
+      // (path needs to be `/connect`); a single `env.sessionCookiePath`
+      // would always pick one and silently break logins on the other.
+      path: await cookiePathForRequest(req),
       secure: env.sessionSecure,
       sameSite: env.sessionSameSite,
       maxAge: 8 * 60 * 60 * 1000,
@@ -266,11 +307,9 @@ portalRouter.post(
     });
     res.cookie(SESSION_COOKIE, token, {
       httpOnly: true,
-      // Distribution mode: scope to BASE_PATH so a sibling Vibe app on the
-      // same host can't read the portal cookie (single-app: '/'; multi-app:
-      // '/connect'). clearCookie below uses the same path so logout works
-      // regardless of mode.
-      path: env.sessionCookiePath,
+      // Per-request path — see the matching block in /verify above for
+      // the multi-subdomain rationale.
+      path: await cookiePathForRequest(req),
       secure: env.sessionSecure,
       sameSite: env.sessionSameSite,
       maxAge: 8 * 60 * 60 * 1000,
@@ -361,7 +400,7 @@ portalRouter.post(
           targetType: 'client_session',
           targetId: session.id,
         });
-        res.clearCookie(SESSION_COOKIE, { path: env.sessionCookiePath });
+        res.clearCookie(SESSION_COOKIE, { path: await cookiePathForRequest(req) });
         res.status(401).json({ error: 'session_revoked' });
         return;
       }
@@ -406,7 +445,9 @@ portalRouter.post(
     });
     res.cookie(SESSION_COOKIE, newToken, {
       httpOnly: true,
-      path: env.sessionCookiePath,
+      // Per-request path (see /verify and /invite blocks above for the
+      // multi-subdomain rationale).
+      path: await cookiePathForRequest(req),
       secure: env.sessionSecure,
       sameSite: env.sessionSameSite,
       // Keep the same remaining lifetime as the absolute_expires_at on the
@@ -460,7 +501,7 @@ portalRouter.post(
         targetId: session.id,
       });
     }
-    res.clearCookie(SESSION_COOKIE, { path: env.sessionCookiePath });
+    res.clearCookie(SESSION_COOKIE, { path: await cookiePathForRequest(req) });
     res.json({ ok: true });
   }),
 );


### PR DESCRIPTION
## User report

> *"I received the code via SMS but it will not login when I enter the code"*

## Root cause

The portal session cookie was inheriting `SESSION_COOKIE_PATH=/connect` from the multi-app appliance setup, but the portal SPA lives at `client.<domain>/` (root, no /connect prefix). Browser refused to send the cookie back for `/portal/*` requests, every `/portal/me` 401'd, and the SPA bounced the user back to the identify page.

Audit-log evidence: `/verify` *succeeded* — `portal.code_verified` + `portal.login` rows landed, plus a fresh row in `client_sessions`. The session was created on the server. The cookie was set on the response. The browser just couldn't send it back because its `Path=/connect` didn't match the `/portal/me` request path.

## Fix

`cookiePathForRequest(req)` mirrors the host-aware basePath derivation in `routes/bootstrap.ts`:

1. Look up `effectiveUrls()` (DB-overridden `portalUrl` + `siteUrl`).
2. Match `req.get('host')` against each URL's host.
3. Return the matched URL's pathname (rstripped of trailing `/`, defaulting to `/`).
4. Fall back to `env.sessionCookiePath` if no URL matches (preserves single-app behaviour and dev/test localhost requests).

Applied to all five cookie touch points in `portal.ts`:

| Endpoint | Action |
|---|---|
| POST /verify (success) | Set-Cookie with derived path |
| POST /invite (acceptance) | Set-Cookie with derived path |
| POST /stepup (post-verify, rotated token) | Set-Cookie with derived path |
| POST /stepup (3-strikes session revoke) | clearCookie with derived path |
| POST /logout | clearCookie with derived path |

Express-session staff cookie (`app.ts:188`) keeps `env.sessionCookiePath` — it's only ever set on the staff host, so per-request derivation isn't needed there.

## Test

`portal-cookie-path.test.ts` seeds an access code via `issueAccessCode`, POSTs `/portal/verify` with three different Host headers, asserts the Set-Cookie response carries the right path:

| Host | portalUrl | siteUrl | Expected `Path=` |
|---|---|---|---|
| `client.cpa2web.app` | `https://client.cpa2web.app` | `https://vibe.cpa2web.app/connect` | `/` |
| `vibe.cpa2web.app` | (same) | (same) | `/connect` |
| `localhost:4000` (no match) | (same) | (same) | `/` (env default) |

**All 3 cases passing.**

## Test plan

- [x] typecheck + lint + format clean
- [x] New regression test passes
- [ ] After v0.4.25 redeploy + client retries login:
  - [ ] Receive SMS code on phone
  - [ ] Enter code on `client.<domain>/verify`
  - [ ] **Lands on `/messages` (or `/stepup` if SSN/EIN verification required), session persists**
  - [ ] DevTools → Application → Cookies → `vibe.portal` cookie is present with `Path=/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)